### PR TITLE
Fix rancher2_cluster_role_template_binding resource saving. Updated acceptance tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,16 @@ To update vendor dependencies, edit `vendor.conf` file and execute trash
 $ trash
 ```
 
+Acceptance tests 
+----------------
+
+For execute acceptance tests, a running rancher HA system and a rancher API key are needed. 
+
+To run acceptance tests, export `RANCHER_URL` with rancher url and `RANCHER_TOKEN_KEY` with bearer token or `RANCHER_ACCESS_KEY` with rancher acces key and `RANCHER_SECRET_KEY` with rancher secret key and execute
+
+```sh
+$ export RANCHER_URL=<URL>
+$ export RANCHER_TOKEN_KEY=<TOKEN>
+$ scripts/testacc
+```
+

--- a/rancher2/config.go
+++ b/rancher2/config.go
@@ -365,3 +365,41 @@ func (c *Config) GetAuthConfig(in *managementClient.AuthConfig) (interface{}, er
 func (c *Config) UpdateAuthConfig(url string, createObj interface{}, respObject interface{}) error {
 	return c.Client.Management.Ops.DoModify("PUT", url, createObj, respObject)
 }
+
+func (c *Config) GetUserByName(name string) (*managementClient.User, error) {
+	if name == "" {
+		return nil, fmt.Errorf("[ERROR] Username is nil")
+	}
+
+	client, err := c.ManagementClient()
+	if err != nil {
+		return nil, err
+	}
+
+	filters := map[string]interface{}{"username": name}
+	listOpts := NewListOpts(filters)
+
+	users, err := client.User.List(listOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, user := range users.Data {
+		if user.Username == name {
+			return &user, nil
+		}
+	}
+	return nil, fmt.Errorf("[ERROR] Username %s not found", name)
+}
+
+func (c *Config) GetUserIDByName(name string) (string, error) {
+	if name == "" {
+		return "", nil
+	}
+
+	user, err := c.GetUserByName(name)
+	if err != nil {
+		return "", err
+	}
+	return user.ID, nil
+}

--- a/rancher2/provider_test.go
+++ b/rancher2/provider_test.go
@@ -29,7 +29,16 @@ func TestProvider_impl(t *testing.T) {
 }
 
 func testAccPreCheck(t *testing.T) {
-	if v := os.Getenv("RANCHER_URL"); v == "" {
+	url := os.Getenv("RANCHER_URL")
+	token := os.Getenv("RANCHER_TOKEN_KEY")
+	accessKey := os.Getenv("RANCHER_ACCESS_KEY")
+	secretKey := os.Getenv("RANCHER_SECRET_KEY")
+
+	if url == "" {
 		t.Fatal("RANCHER_URL must be set for acceptance tests")
+	}
+
+	if token == "" && (accessKey == "" || secretKey == "") {
+		t.Fatal("RANCHER_TOKEN_KEY or RANCHER_ACCESS_KEY and RANCHER_SECRET_KEY must be set for acceptance tests")
 	}
 }

--- a/rancher2/resource_rancher2_catalog_test.go
+++ b/rancher2/resource_rancher2_catalog_test.go
@@ -16,7 +16,7 @@ const (
 resource "rancher2_catalog" "foo" {
   name = "foo"
   url = "http://foo.com:8080"
-  description= "Foo catalog test"
+  description= "Terraform catalog acceptance test"
 }
 `
 
@@ -24,7 +24,7 @@ resource "rancher2_catalog" "foo" {
 resource "rancher2_catalog" "foo" {
   name = "foo"
   url = "http://foo.updated.com:8080"
-  description= "Foo catalog test - updated"
+  description= "Terraform catalog acceptance test - updated"
 }
  `
 
@@ -32,7 +32,7 @@ resource "rancher2_catalog" "foo" {
 resource "rancher2_catalog" "foo" {
   name = "foo"
   url = "http://foo.com:8080"
-  description= "Foo catalog test"
+  description= "Terraform catalog acceptance test"
 }
  `
 )
@@ -50,7 +50,7 @@ func TestAccRancher2Catalog_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRancher2CatalogExists(testAccRancher2CatalogType+".foo", catalog),
 					resource.TestCheckResourceAttr(testAccRancher2CatalogType+".foo", "name", "foo"),
-					resource.TestCheckResourceAttr(testAccRancher2CatalogType+".foo", "description", "Foo catalog test"),
+					resource.TestCheckResourceAttr(testAccRancher2CatalogType+".foo", "description", "Terraform catalog acceptance test"),
 					resource.TestCheckResourceAttr(testAccRancher2CatalogType+".foo", "url", "http://foo.com:8080"),
 				),
 			},
@@ -59,7 +59,7 @@ func TestAccRancher2Catalog_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRancher2CatalogExists(testAccRancher2CatalogType+".foo", catalog),
 					resource.TestCheckResourceAttr(testAccRancher2CatalogType+".foo", "name", "foo"),
-					resource.TestCheckResourceAttr(testAccRancher2CatalogType+".foo", "description", "Foo catalog test - updated"),
+					resource.TestCheckResourceAttr(testAccRancher2CatalogType+".foo", "description", "Terraform catalog acceptance test - updated"),
 					resource.TestCheckResourceAttr(testAccRancher2CatalogType+".foo", "url", "http://foo.updated.com:8080"),
 				),
 			},
@@ -68,7 +68,7 @@ func TestAccRancher2Catalog_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRancher2CatalogExists(testAccRancher2CatalogType+".foo", catalog),
 					resource.TestCheckResourceAttr(testAccRancher2CatalogType+".foo", "name", "foo"),
-					resource.TestCheckResourceAttr(testAccRancher2CatalogType+".foo", "description", "Foo catalog test"),
+					resource.TestCheckResourceAttr(testAccRancher2CatalogType+".foo", "description", "Terraform catalog acceptance test"),
 					resource.TestCheckResourceAttr(testAccRancher2CatalogType+".foo", "url", "http://foo.com:8080"),
 				),
 			},

--- a/rancher2/resource_rancher2_cluster_role_template_binding.go
+++ b/rancher2/resource_rancher2_cluster_role_template_binding.go
@@ -203,7 +203,7 @@ func resourceRancher2ClusterRoleTemplateBindingCreate(d *schema.ResourceData, me
 			"[ERROR] waiting for cluster role template binding (%s) to be created: %s", newClusterRole.ID, waitErr)
 	}
 
-	err = flattenClusterRoleTemplateBinding(d, clusterRole)
+	err = flattenClusterRoleTemplateBinding(d, newClusterRole)
 	if err != nil {
 		return err
 	}

--- a/rancher2/resource_rancher2_cluster_role_template_binding_test.go
+++ b/rancher2/resource_rancher2_cluster_role_template_binding_test.go
@@ -24,8 +24,7 @@ resource "rancher2_cluster_role_template_binding" "foo" {
 resource "rancher2_cluster_role_template_binding" "foo" {
   name = "foo"
   cluster_id = "local"
-  role_template_id = "project-member"
-  user_id = "u-q2wg7"
+  role_template_id = "project-owner"
 }
  `
 
@@ -61,8 +60,7 @@ func TestAccRancher2ClusterRoleTemplateBinding_basic(t *testing.T) {
 					testAccCheckRancher2ClusterRoleTemplateBindingExists(testAccRancher2ClusterRoleTemplateBindingType+".foo", clusterRole),
 					resource.TestCheckResourceAttr(testAccRancher2ClusterRoleTemplateBindingType+".foo", "name", "foo"),
 					resource.TestCheckResourceAttr(testAccRancher2ClusterRoleTemplateBindingType+".foo", "cluster_id", "local"),
-					resource.TestCheckResourceAttr(testAccRancher2ClusterRoleTemplateBindingType+".foo", "role_template_id", "project-member"),
-					resource.TestCheckResourceAttr(testAccRancher2ClusterRoleTemplateBindingType+".foo", "user_id", "u-q2wg7"),
+					resource.TestCheckResourceAttr(testAccRancher2ClusterRoleTemplateBindingType+".foo", "role_template_id", "project-owner"),
 				),
 			},
 			resource.TestStep{

--- a/rancher2/resource_rancher2_cluster_test.go
+++ b/rancher2/resource_rancher2_cluster_test.go
@@ -1,0 +1,292 @@
+package rancher2
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	managementClient "github.com/rancher/types/client/management/v3"
+)
+
+const (
+	testAccRancher2ClusterType      = "rancher2_cluster"
+	testAccRancher2ClusterConfigRKE = `
+resource "rancher2_cluster" "foo" {
+  name = "foo"
+  description = "Terraform custom cluster acceptance test"
+  kind = "rke"
+  rke_config {
+    network {
+      plugin = "canal"
+    }
+  }
+}
+`
+
+	testAccRancher2ClusterUpdateConfigRKE = `
+resource "rancher2_cluster" "foo" {
+  name = "foo"
+  description = "Terraform custom cluster acceptance test - updated"
+  kind = "rke"
+  rke_config {
+    network {
+      plugin = "canal"
+    }
+  }
+}
+ `
+
+	testAccRancher2ClusterRecreateConfigRKE = `
+resource "rancher2_cluster" "foo" {
+  name = "foo"
+  description = "Terraform custom cluster acceptance test"
+  kind = "rke"
+  rke_config {
+    network {
+      plugin = "canal"
+    }
+  }
+}
+ `
+
+	testAccRancher2ClusterConfigImported = `
+resource "rancher2_cluster" "foo" {
+  name = "foo"
+  description = "Terraform imported cluster acceptance test"
+  kind = "imported"
+}
+`
+
+	testAccRancher2ClusterUpdateConfigImported = `
+resource "rancher2_cluster" "foo" {
+  name = "foo"
+  description = "Terraform imported cluster acceptance test - updated"
+  kind = "imported"
+}
+ `
+
+	testAccRancher2ClusterRecreateConfigImported = `
+resource "rancher2_cluster" "foo" {
+  name = "foo"
+  description = "Terraform imported cluster acceptance test"
+  kind = "imported"
+}
+ `
+)
+
+func TestAccRancher2Cluster_basic_RKE(t *testing.T) {
+	var cluster *managementClient.Cluster
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRancher2ClusterDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRancher2ClusterConfigRKE,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2ClusterExists(testAccRancher2ClusterType+".foo", cluster),
+					resource.TestCheckResourceAttr(testAccRancher2ClusterType+".foo", "name", "foo"),
+					resource.TestCheckResourceAttr(testAccRancher2ClusterType+".foo", "description", "Terraform custom cluster acceptance test"),
+					resource.TestCheckResourceAttr(testAccRancher2ClusterType+".foo", "kind", "rke"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccRancher2ClusterUpdateConfigRKE,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2ClusterExists(testAccRancher2ClusterType+".foo", cluster),
+					resource.TestCheckResourceAttr(testAccRancher2ClusterType+".foo", "name", "foo"),
+					resource.TestCheckResourceAttr(testAccRancher2ClusterType+".foo", "description", "Terraform custom cluster acceptance test - updated"),
+					resource.TestCheckResourceAttr(testAccRancher2ClusterType+".foo", "kind", "rke"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccRancher2ClusterRecreateConfigRKE,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2ClusterExists(testAccRancher2ClusterType+".foo", cluster),
+					resource.TestCheckResourceAttr(testAccRancher2ClusterType+".foo", "name", "foo"),
+					resource.TestCheckResourceAttr(testAccRancher2ClusterType+".foo", "description", "Terraform custom cluster acceptance test"),
+					resource.TestCheckResourceAttr(testAccRancher2ClusterType+".foo", "kind", "rke"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRancher2Cluster_disappears_RKE(t *testing.T) {
+	var cluster *managementClient.Cluster
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRancher2ClusterDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRancher2ClusterConfigRKE,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2ClusterExists(testAccRancher2ClusterType+".foo", cluster),
+					testAccRancher2ClusterDisappears(cluster),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccRancher2Cluster_basic_Imported(t *testing.T) {
+	var cluster *managementClient.Cluster
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRancher2ClusterDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRancher2ClusterConfigImported,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2ClusterExists(testAccRancher2ClusterType+".foo", cluster),
+					resource.TestCheckResourceAttr(testAccRancher2ClusterType+".foo", "name", "foo"),
+					resource.TestCheckResourceAttr(testAccRancher2ClusterType+".foo", "description", "Terraform imported cluster acceptance test"),
+					resource.TestCheckResourceAttr(testAccRancher2ClusterType+".foo", "kind", "imported"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccRancher2ClusterUpdateConfigImported,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2ClusterExists(testAccRancher2ClusterType+".foo", cluster),
+					resource.TestCheckResourceAttr(testAccRancher2ClusterType+".foo", "name", "foo"),
+					resource.TestCheckResourceAttr(testAccRancher2ClusterType+".foo", "description", "Terraform imported cluster acceptance test - updated"),
+					resource.TestCheckResourceAttr(testAccRancher2ClusterType+".foo", "kind", "imported"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccRancher2ClusterRecreateConfigImported,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2ClusterExists(testAccRancher2ClusterType+".foo", cluster),
+					resource.TestCheckResourceAttr(testAccRancher2ClusterType+".foo", "name", "foo"),
+					resource.TestCheckResourceAttr(testAccRancher2ClusterType+".foo", "description", "Terraform imported cluster acceptance test"),
+					resource.TestCheckResourceAttr(testAccRancher2ClusterType+".foo", "kind", "imported"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRancher2Cluster_disappears_Imported(t *testing.T) {
+	var cluster *managementClient.Cluster
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRancher2ClusterDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRancher2ClusterConfigImported,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2ClusterExists(testAccRancher2ClusterType+".foo", cluster),
+					testAccRancher2ClusterDisappears(cluster),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccRancher2ClusterDisappears(pro *managementClient.Cluster) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != testAccRancher2ClusterType {
+				continue
+			}
+			client, err := testAccProvider.Meta().(*Config).ManagementClient()
+			if err != nil {
+				return err
+			}
+
+			pro, err = client.Cluster.ByID(rs.Primary.ID)
+			if err != nil {
+				if IsNotFound(err) {
+					return nil
+				}
+				return err
+			}
+
+			err = client.Cluster.Delete(pro)
+			if err != nil {
+				return fmt.Errorf("Error removing Cluster: %s", err)
+			}
+
+			stateConf := &resource.StateChangeConf{
+				Pending:    []string{"active", "removing"},
+				Target:     []string{"removed"},
+				Refresh:    clusterRegistrationTokenStateRefreshFunc(client, pro.ID),
+				Timeout:    10 * time.Minute,
+				Delay:      1 * time.Second,
+				MinTimeout: 3 * time.Second,
+			}
+
+			_, waitErr := stateConf.WaitForState()
+			if waitErr != nil {
+				return fmt.Errorf(
+					"[ERROR] waiting for Cluster (%s) to be removed: %s", pro.ID, waitErr)
+			}
+		}
+		return nil
+
+	}
+}
+
+func testAccCheckRancher2ClusterExists(n string, pro *managementClient.Cluster) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Cluster ID is set")
+		}
+
+		client, err := testAccProvider.Meta().(*Config).ManagementClient()
+		if err != nil {
+			return err
+		}
+
+		foundPro, err := client.Cluster.ByID(rs.Primary.ID)
+		if err != nil {
+			if IsNotFound(err) {
+				return fmt.Errorf("Cluster not found")
+			}
+			return err
+		}
+
+		pro = foundPro
+
+		return nil
+	}
+}
+
+func testAccCheckRancher2ClusterDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != testAccRancher2ClusterType {
+			continue
+		}
+		client, err := testAccProvider.Meta().(*Config).ManagementClient()
+		if err != nil {
+			return err
+		}
+
+		_, err = client.Cluster.ByID(rs.Primary.ID)
+		if err != nil {
+			if IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+		return fmt.Errorf("Cluster still exists")
+	}
+	return nil
+}

--- a/rancher2/resource_rancher2_namespace.go
+++ b/rancher2/resource_rancher2_namespace.go
@@ -358,10 +358,6 @@ func namespaceStateRefreshFunc(client *clusterClient.Client, nsID string) resour
 			return nil, "", err
 		}
 
-		if obj.Removed != "" {
-			return obj, "removed", nil
-		}
-
 		return obj, obj.State, nil
 	}
 }

--- a/rancher2/resource_rancher2_project_role_template_binding_test.go
+++ b/rancher2/resource_rancher2_project_role_template_binding_test.go
@@ -11,28 +11,36 @@ import (
 )
 
 const (
-	testAccRancher2ProjectRoleTemplateBindingType   = "rancher2_project_role_template_binding"
-	testAccRancher2ProjectRoleTemplateBindingConfig = `
+	testAccRancher2ProjectRoleTemplateBindingType = "rancher2_project_role_template_binding"
+
+	testAccRancher2ProjectRoleTemplateBindingProject = `
+resource "rancher2_project" "foo" {
+  name = "foo"
+  cluster_id = "local"
+  description = "Terraform project role template binding acceptance test"
+}
+`
+	testAccRancher2ProjectRoleTemplateBindingConfig = testAccRancher2ProjectRoleTemplateBindingProject + `
 resource "rancher2_project_role_template_binding" "foo" {
   name = "foo"
-  project_id = "local:p-2lk7g"
+  project_id = "${rancher2_project.foo.id}"
   role_template_id = "project-member"
 }
 `
 
-	testAccRancher2ProjectRoleTemplateBindingUpdateConfig = `
+	testAccRancher2ProjectRoleTemplateBindingUpdateConfig = testAccRancher2ProjectRoleTemplateBindingProject + `
 resource "rancher2_project_role_template_binding" "foo" {
   name = "foo"
-  project_id = "local:p-2lk7g"
-  role_template_id = "project-member"
+  project_id = "${rancher2_project.foo.id}"
+  role_template_id = "project-owner"
   user_id = "u-q2wg7"
 }
  `
 
-	testAccRancher2ProjectRoleTemplateBindingRecreateConfig = `
+	testAccRancher2ProjectRoleTemplateBindingRecreateConfig = testAccRancher2ProjectRoleTemplateBindingProject + `
 resource "rancher2_project_role_template_binding" "foo" {
   name = "foo"
-  project_id = "local:p-2lk7g"
+  project_id = "${rancher2_project.foo.id}"
   role_template_id = "project-member"
 }
  `
@@ -51,7 +59,6 @@ func TestAccRancher2ProjectRoleTemplateBinding_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRancher2ProjectRoleTemplateBindingExists(testAccRancher2ProjectRoleTemplateBindingType+".foo", projectRole),
 					resource.TestCheckResourceAttr(testAccRancher2ProjectRoleTemplateBindingType+".foo", "name", "foo"),
-					resource.TestCheckResourceAttr(testAccRancher2ProjectRoleTemplateBindingType+".foo", "project_id", "local:p-2lk7g"),
 					resource.TestCheckResourceAttr(testAccRancher2ProjectRoleTemplateBindingType+".foo", "role_template_id", "project-member"),
 				),
 			},
@@ -60,8 +67,7 @@ func TestAccRancher2ProjectRoleTemplateBinding_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRancher2ProjectRoleTemplateBindingExists(testAccRancher2ProjectRoleTemplateBindingType+".foo", projectRole),
 					resource.TestCheckResourceAttr(testAccRancher2ProjectRoleTemplateBindingType+".foo", "name", "foo"),
-					resource.TestCheckResourceAttr(testAccRancher2ProjectRoleTemplateBindingType+".foo", "project_id", "local:p-2lk7g"),
-					resource.TestCheckResourceAttr(testAccRancher2ProjectRoleTemplateBindingType+".foo", "role_template_id", "project-member"),
+					resource.TestCheckResourceAttr(testAccRancher2ProjectRoleTemplateBindingType+".foo", "role_template_id", "project-owner"),
 					resource.TestCheckResourceAttr(testAccRancher2ProjectRoleTemplateBindingType+".foo", "user_id", "u-q2wg7"),
 				),
 			},
@@ -70,7 +76,6 @@ func TestAccRancher2ProjectRoleTemplateBinding_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRancher2ProjectRoleTemplateBindingExists(testAccRancher2ProjectRoleTemplateBindingType+".foo", projectRole),
 					resource.TestCheckResourceAttr(testAccRancher2ProjectRoleTemplateBindingType+".foo", "name", "foo"),
-					resource.TestCheckResourceAttr(testAccRancher2ProjectRoleTemplateBindingType+".foo", "project_id", "local:p-2lk7g"),
 					resource.TestCheckResourceAttr(testAccRancher2ProjectRoleTemplateBindingType+".foo", "role_template_id", "project-member"),
 				),
 			},

--- a/rancher2/resource_rancher2_project_test.go
+++ b/rancher2/resource_rancher2_project_test.go
@@ -16,7 +16,7 @@ const (
 resource "rancher2_project" "foo" {
   name = "foo"
   cluster_id = "local"
-  description = "Foo project test"
+  description = "Terraform project acceptance test"
 }
 `
 
@@ -24,7 +24,7 @@ resource "rancher2_project" "foo" {
 resource "rancher2_project" "foo" {
   name = "foo-updated"
   cluster_id = "local"
-  description = "Foo project test - updated"
+  description = "Terraform project acceptance test - updated"
 }
  `
 
@@ -32,7 +32,7 @@ resource "rancher2_project" "foo" {
 resource "rancher2_project" "foo" {
   name = "foo"
   cluster_id = "local"
-  description = "Foo project test"
+  description = "Terraform project acceptance test"
 }
  `
 )
@@ -50,7 +50,7 @@ func TestAccRancher2Project_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRancher2ProjectExists(testAccRancher2ProjectType+".foo", project),
 					resource.TestCheckResourceAttr(testAccRancher2ProjectType+".foo", "name", "foo"),
-					resource.TestCheckResourceAttr(testAccRancher2ProjectType+".foo", "description", "Foo project test"),
+					resource.TestCheckResourceAttr(testAccRancher2ProjectType+".foo", "description", "Terraform project acceptance test"),
 					resource.TestCheckResourceAttr(testAccRancher2ProjectType+".foo", "cluster_id", "local"),
 				),
 			},
@@ -59,7 +59,7 @@ func TestAccRancher2Project_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRancher2ProjectExists(testAccRancher2ProjectType+".foo", project),
 					resource.TestCheckResourceAttr(testAccRancher2ProjectType+".foo", "name", "foo-updated"),
-					resource.TestCheckResourceAttr(testAccRancher2ProjectType+".foo", "description", "Foo project test - updated"),
+					resource.TestCheckResourceAttr(testAccRancher2ProjectType+".foo", "description", "Terraform project acceptance test - updated"),
 					resource.TestCheckResourceAttr(testAccRancher2ProjectType+".foo", "cluster_id", "local"),
 				),
 			},
@@ -68,7 +68,7 @@ func TestAccRancher2Project_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRancher2ProjectExists(testAccRancher2ProjectType+".foo", project),
 					resource.TestCheckResourceAttr(testAccRancher2ProjectType+".foo", "name", "foo"),
-					resource.TestCheckResourceAttr(testAccRancher2ProjectType+".foo", "description", "Foo project test"),
+					resource.TestCheckResourceAttr(testAccRancher2ProjectType+".foo", "description", "Terraform project acceptance test"),
 					resource.TestCheckResourceAttr(testAccRancher2ProjectType+".foo", "cluster_id", "local"),
 				),
 			},

--- a/scripts/test
+++ b/scripts/test
@@ -5,6 +5,6 @@ cd $(dirname $0)/..
 
 echo Running tests
 
-PACKAGES=". $(find -name '*.go' | xargs -I{} dirname {} |  cut -f2 -d/ | sort -u | grep -Ev '(^\.$|.git|.trash-cache|vendor|bin)' | sed -e 's!^!./!' -e 's!$!/...!')"
+PACKAGES="$(find . -name '*.go' | xargs -I{} dirname {} |  cut -f2 -d/ | sort -u | grep -Ev '(^\.$|.git|.trash-cache|vendor|bin)' | sed -e 's!^!./!' -e 's!$!/...!')"
 
 go test -race -cover -tags=test ${PACKAGES}

--- a/scripts/testacc
+++ b/scripts/testacc
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+RANCHER_URL=${RANCHER_URL:-""}
+RANCHER_TOKEN_KEY=${RANCHER_TOKEN_KEY:-""}
+RANCHER_ACCESS_KEY=${RANCHER_ACCESS_KEY:-""}
+RANCHER_SECRET_KEY=${RANCHER_SECRET_KEY:-""}
+
+cd $(dirname $0)/..
+
+echo Running acceptance tests
+
+PACKAGES="$(find . -name '*.go' | xargs -I{} dirname {} |  cut -f2 -d/ | sort -u | grep -Ev '(^\.$|.git|.trash-cache|vendor|bin)' | sed -e 's!^!./!' -e 's!$!/...!')"
+
+TF_ACC=1 go test -race -cover -tags=test ${PACKAGES} -v -timeout 120m


### PR DESCRIPTION
This PR constains:
- Fix for rancher2_cluster_role_template_binding resource save on terraform tfstate.
- Removing hardcoded data for acceptance tests.
- Added tests for rancher2_cluster resources of kind `rke` and `imported`.
- Updated README.md adding instructions for acceptance tests.

A running rancher HA system and a rancher API key are needed to pass acceptance tests. 