### PR TITLE
Added option for insecure connection 

### DIFF
--- a/rancher2/config.go
+++ b/rancher2/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	CACerts   string `json:"cacert"`
 	ClusterID string `json:"clusterId"`
 	ProjectID string `json:"projectId"`
+	Insecure  bool   `json:"insecure"`
 	Client    Client
 }
 
@@ -114,6 +115,7 @@ func (c *Config) CreateClientOpts() *clientbase.ClientOpts {
 		SecretKey: c.SecretKey,
 		TokenKey:  c.TokenKey,
 		CACerts:   c.CACerts,
+		Insecure:  c.Insecure,
 	}
 
 	return options


### PR DESCRIPTION
Added option for insecure connection.

This is mainly useful for local development when using `docker run rancher/rancher`. 
With this, we do not need to fetch the generated certificate is in the docker image. 

