### PR TITLE
Bootstrap feature. rke dind ATT. namespace move. Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Features WIP
   - FreeIpa
   - OpenLdap
   - Ping
+- Bootstrap Rancher system
 - Catalogs
 - Clusters
   - Amazon EKS
@@ -42,6 +43,7 @@ Features WIP
 - Node Driver
 - Projects
   - Resource quota limits (Rancher v2.1.x or higher )
+- Settings
 
 TODO
 

--- a/rancher2/data_source_rancher2_setting.go
+++ b/rancher2/data_source_rancher2_setting.go
@@ -33,7 +33,7 @@ func dataSourceRancher2SettingRead(d *schema.ResourceData, meta interface{}) err
 	}
 
 	setting, err := client.Setting.ByID(name)
-	if err != nil {
+	if err != nil || setting == nil {
 		return err
 	}
 

--- a/rancher2/resource_rancher2_cluster_logging_test.go
+++ b/rancher2/resource_rancher2_cluster_logging_test.go
@@ -11,11 +11,20 @@ import (
 )
 
 const (
-	testAccRancher2ClusterLoggingType         = "rancher2_cluster_logging"
+	testAccRancher2ClusterLoggingType = "rancher2_cluster_logging"
+)
+
+var (
+	testAccRancher2ClusterLoggingConfigSyslog         string
+	testAccRancher2ClusterLoggingUpdateConfigSyslog   string
+	testAccRancher2ClusterLoggingRecreateConfigSyslog string
+)
+
+func init() {
 	testAccRancher2ClusterLoggingConfigSyslog = `
 resource "rancher2_cluster_logging" "foo" {
   name = "foo"
-  cluster_id = "local"
+  cluster_id = "` + testAccRancher2ClusterID + `"
   kind = "syslog"
   syslog_config {
     endpoint = "192.168.1.1:514"
@@ -29,7 +38,7 @@ resource "rancher2_cluster_logging" "foo" {
 	testAccRancher2ClusterLoggingUpdateConfigSyslog = `
 resource "rancher2_cluster_logging" "foo" {
   name = "foo-updated"
-  cluster_id = "local"
+  cluster_id = "` + testAccRancher2ClusterID + `"
   kind = "syslog"
   syslog_config {
     endpoint = "192.168.1.1:514"
@@ -43,7 +52,7 @@ resource "rancher2_cluster_logging" "foo" {
 	testAccRancher2ClusterLoggingRecreateConfigSyslog = `
 resource "rancher2_cluster_logging" "foo" {
   name = "foo"
-  cluster_id = "local"
+  cluster_id = "` + testAccRancher2ClusterID + `"
   kind = "syslog"
   syslog_config {
     endpoint = "192.168.1.1:514"
@@ -53,13 +62,12 @@ resource "rancher2_cluster_logging" "foo" {
   }
 }
  `
-)
+}
 
 func TestAccRancher2ClusterLogging_basic_syslog(t *testing.T) {
 	var cluster *managementClient.ClusterLogging
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRancher2ClusterLoggingDestroy,
 		Steps: []resource.TestStep{
@@ -68,7 +76,7 @@ func TestAccRancher2ClusterLogging_basic_syslog(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRancher2ClusterLoggingExists(testAccRancher2ClusterLoggingType+".foo", cluster),
 					resource.TestCheckResourceAttr(testAccRancher2ClusterLoggingType+".foo", "name", "foo"),
-					resource.TestCheckResourceAttr(testAccRancher2ClusterLoggingType+".foo", "cluster_id", "local"),
+					resource.TestCheckResourceAttr(testAccRancher2ClusterLoggingType+".foo", "cluster_id", testAccRancher2ClusterID),
 				),
 			},
 			resource.TestStep{
@@ -76,7 +84,7 @@ func TestAccRancher2ClusterLogging_basic_syslog(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRancher2ClusterLoggingExists(testAccRancher2ClusterLoggingType+".foo", cluster),
 					resource.TestCheckResourceAttr(testAccRancher2ClusterLoggingType+".foo", "name", "foo-updated"),
-					resource.TestCheckResourceAttr(testAccRancher2ClusterLoggingType+".foo", "cluster_id", "local"),
+					resource.TestCheckResourceAttr(testAccRancher2ClusterLoggingType+".foo", "cluster_id", testAccRancher2ClusterID),
 				),
 			},
 			resource.TestStep{
@@ -84,7 +92,7 @@ func TestAccRancher2ClusterLogging_basic_syslog(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRancher2ClusterLoggingExists(testAccRancher2ClusterLoggingType+".foo", cluster),
 					resource.TestCheckResourceAttr(testAccRancher2ClusterLoggingType+".foo", "name", "foo"),
-					resource.TestCheckResourceAttr(testAccRancher2ClusterLoggingType+".foo", "cluster_id", "local"),
+					resource.TestCheckResourceAttr(testAccRancher2ClusterLoggingType+".foo", "cluster_id", testAccRancher2ClusterID),
 				),
 			},
 		},
@@ -95,7 +103,6 @@ func TestAccRancher2ClusterLogging_disappears_syslog(t *testing.T) {
 	var cluster *managementClient.ClusterLogging
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRancher2ClusterLoggingDestroy,
 		Steps: []resource.TestStep{

--- a/rancher2/resource_rancher2_cluster_role_template_binding_test.go
+++ b/rancher2/resource_rancher2_cluster_role_template_binding_test.go
@@ -11,11 +11,20 @@ import (
 )
 
 const (
-	testAccRancher2ClusterRoleTemplateBindingType   = "rancher2_cluster_role_template_binding"
+	testAccRancher2ClusterRoleTemplateBindingType = "rancher2_cluster_role_template_binding"
+)
+
+var (
+	testAccRancher2ClusterRoleTemplateBindingConfig         string
+	testAccRancher2ClusterRoleTemplateBindingUpdateConfig   string
+	testAccRancher2ClusterRoleTemplateBindingRecreateConfig string
+)
+
+func init() {
 	testAccRancher2ClusterRoleTemplateBindingConfig = `
 resource "rancher2_cluster_role_template_binding" "foo" {
   name = "foo"
-  cluster_id = "local"
+  cluster_id = "` + testAccRancher2ClusterID + `"
   role_template_id = "project-member"
 }
 `
@@ -23,7 +32,7 @@ resource "rancher2_cluster_role_template_binding" "foo" {
 	testAccRancher2ClusterRoleTemplateBindingUpdateConfig = `
 resource "rancher2_cluster_role_template_binding" "foo" {
   name = "foo"
-  cluster_id = "local"
+  cluster_id = "` + testAccRancher2ClusterID + `"
   role_template_id = "project-owner"
 }
  `
@@ -31,17 +40,16 @@ resource "rancher2_cluster_role_template_binding" "foo" {
 	testAccRancher2ClusterRoleTemplateBindingRecreateConfig = `
 resource "rancher2_cluster_role_template_binding" "foo" {
   name = "foo"
-  cluster_id = "local"
+  cluster_id = "` + testAccRancher2ClusterID + `"
   role_template_id = "project-member"
 }
  `
-)
+}
 
 func TestAccRancher2ClusterRoleTemplateBinding_basic(t *testing.T) {
 	var clusterRole *managementClient.ClusterRoleTemplateBinding
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRancher2ClusterRoleTemplateBindingDestroy,
 		Steps: []resource.TestStep{
@@ -50,7 +58,7 @@ func TestAccRancher2ClusterRoleTemplateBinding_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRancher2ClusterRoleTemplateBindingExists(testAccRancher2ClusterRoleTemplateBindingType+".foo", clusterRole),
 					resource.TestCheckResourceAttr(testAccRancher2ClusterRoleTemplateBindingType+".foo", "name", "foo"),
-					resource.TestCheckResourceAttr(testAccRancher2ClusterRoleTemplateBindingType+".foo", "cluster_id", "local"),
+					resource.TestCheckResourceAttr(testAccRancher2ClusterRoleTemplateBindingType+".foo", "cluster_id", testAccRancher2ClusterID),
 					resource.TestCheckResourceAttr(testAccRancher2ClusterRoleTemplateBindingType+".foo", "role_template_id", "project-member"),
 				),
 			},
@@ -59,7 +67,7 @@ func TestAccRancher2ClusterRoleTemplateBinding_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRancher2ClusterRoleTemplateBindingExists(testAccRancher2ClusterRoleTemplateBindingType+".foo", clusterRole),
 					resource.TestCheckResourceAttr(testAccRancher2ClusterRoleTemplateBindingType+".foo", "name", "foo"),
-					resource.TestCheckResourceAttr(testAccRancher2ClusterRoleTemplateBindingType+".foo", "cluster_id", "local"),
+					resource.TestCheckResourceAttr(testAccRancher2ClusterRoleTemplateBindingType+".foo", "cluster_id", testAccRancher2ClusterID),
 					resource.TestCheckResourceAttr(testAccRancher2ClusterRoleTemplateBindingType+".foo", "role_template_id", "project-owner"),
 				),
 			},
@@ -68,7 +76,7 @@ func TestAccRancher2ClusterRoleTemplateBinding_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRancher2ClusterRoleTemplateBindingExists(testAccRancher2ClusterRoleTemplateBindingType+".foo", clusterRole),
 					resource.TestCheckResourceAttr(testAccRancher2ClusterRoleTemplateBindingType+".foo", "name", "foo"),
-					resource.TestCheckResourceAttr(testAccRancher2ClusterRoleTemplateBindingType+".foo", "cluster_id", "local"),
+					resource.TestCheckResourceAttr(testAccRancher2ClusterRoleTemplateBindingType+".foo", "cluster_id", testAccRancher2ClusterID),
 					resource.TestCheckResourceAttr(testAccRancher2ClusterRoleTemplateBindingType+".foo", "role_template_id", "project-member"),
 				),
 			},
@@ -80,7 +88,6 @@ func TestAccRancher2ClusterRoleTemplateBinding_disappears(t *testing.T) {
 	var clusterRole *managementClient.ClusterRoleTemplateBinding
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRancher2ClusterRoleTemplateBindingDestroy,
 		Steps: []resource.TestStep{

--- a/rancher2/resource_rancher2_namespace_test.go
+++ b/rancher2/resource_rancher2_namespace_test.go
@@ -11,11 +11,21 @@ import (
 )
 
 const (
-	testAccRancher2NamespaceType    = "rancher2_namespace"
+	testAccRancher2NamespaceType = "rancher2_namespace"
+)
+
+var (
+	testAccRancher2NamespaceProject        string
+	testAccRancher2NamespaceConfig         string
+	testAccRancher2NamespaceUpdateConfig   string
+	testAccRancher2NamespaceRecreateConfig string
+)
+
+func init() {
 	testAccRancher2NamespaceProject = `
 resource "rancher2_project" "foo" {
   name = "foo"
-  cluster_id = "local"
+  cluster_id = "` + testAccRancher2ClusterID + `"
   description = "Terraform namespace acceptance test"
   resource_quota {
     project_limit {
@@ -76,13 +86,12 @@ resource "rancher2_namespace" "foo" {
   }
 }
  `
-)
+}
 
 func TestAccRancher2Namespace_basic(t *testing.T) {
 	var ns *clusterClient.Namespace
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRancher2NamespaceDestroy,
 		Steps: []resource.TestStep{
@@ -118,7 +127,6 @@ func TestAccRancher2Namespace_disappears(t *testing.T) {
 	var ns *clusterClient.Namespace
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRancher2NamespaceDestroy,
 		Steps: []resource.TestStep{

--- a/rancher2/resource_rancher2_node_driver.go
+++ b/rancher2/resource_rancher2_node_driver.go
@@ -216,7 +216,7 @@ func resourceRancher2NodeDriverCreate(d *schema.ResourceData, meta interface{}) 
 	}
 	_, waitErr := stateConf.WaitForState()
 	if waitErr != nil {
-		return fmt.Errorf("[ERROR] waiting for node pool (%s) to be created: %s", newNodeDriver.ID, waitErr)
+		return fmt.Errorf("[ERROR] waiting for node driver (%s) to be created: %s", newNodeDriver.ID, waitErr)
 	}
 
 	d.SetId(newNodeDriver.ID)
@@ -285,7 +285,7 @@ func resourceRancher2NodeDriverUpdate(d *schema.ResourceData, meta interface{}) 
 	_, waitErr := stateConf.WaitForState()
 	if waitErr != nil {
 		return fmt.Errorf(
-			"[ERROR] waiting for node pool (%s) to be updated: %s", newNodeDriver.ID, waitErr)
+			"[ERROR] waiting for node driver (%s) to be updated: %s", newNodeDriver.ID, waitErr)
 	}
 
 	return resourceRancher2NodeDriverRead(d, meta)
@@ -328,7 +328,7 @@ func resourceRancher2NodeDriverDelete(d *schema.ResourceData, meta interface{}) 
 	_, waitErr := stateConf.WaitForState()
 	if waitErr != nil {
 		return fmt.Errorf(
-			"[ERROR] waiting for node pool (%s) to be removed: %s", id, waitErr)
+			"[ERROR] waiting for node driver (%s) to be removed: %s", id, waitErr)
 	}
 
 	d.SetId("")

--- a/rancher2/resource_rancher2_project.go
+++ b/rancher2/resource_rancher2_project.go
@@ -175,7 +175,7 @@ func resourceRancher2ProjectCreate(d *schema.ResourceData, meta interface{}) err
 	}
 
 	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"active"},
+		Pending:    []string{"initializing", "configuring", "active"},
 		Target:     []string{"active"},
 		Refresh:    projectStateRefreshFunc(client, newProject.ID),
 		Timeout:    d.Timeout(schema.TimeoutCreate),

--- a/rancher2/resource_rancher2_project_logging_test.go
+++ b/rancher2/resource_rancher2_project_logging_test.go
@@ -11,11 +11,21 @@ import (
 )
 
 const (
-	testAccRancher2ProjectLoggingType    = "rancher2_project_logging"
+	testAccRancher2ProjectLoggingType = "rancher2_project_logging"
+)
+
+var (
+	testAccRancher2ProjectLoggingProject              string
+	testAccRancher2ProjectLoggingConfigSyslog         string
+	testAccRancher2ProjectLoggingUpdateConfigSyslog   string
+	testAccRancher2ProjectLoggingRecreateConfigSyslog string
+)
+
+func init() {
 	testAccRancher2ProjectLoggingProject = `
 resource "rancher2_project" "foo" {
   name = "foo"
-  cluster_id = "local"
+  cluster_id = "` + testAccRancher2ClusterID + `"
   description = "Terraform Project Logging acceptance test"
 }
 `
@@ -60,13 +70,12 @@ resource "rancher2_project_logging" "foo" {
   }
 }
  `
-)
+}
 
 func TestAccRancher2ProjectLogging_basic_syslog(t *testing.T) {
 	var project *managementClient.ProjectLogging
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRancher2ProjectLoggingDestroy,
 		Steps: []resource.TestStep{
@@ -102,7 +111,6 @@ func TestAccRancher2ProjectLogging_disappears_syslog(t *testing.T) {
 	var project *managementClient.ProjectLogging
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRancher2ProjectLoggingDestroy,
 		Steps: []resource.TestStep{

--- a/rancher2/resource_rancher2_project_role_template_binding_test.go
+++ b/rancher2/resource_rancher2_project_role_template_binding_test.go
@@ -12,11 +12,20 @@ import (
 
 const (
 	testAccRancher2ProjectRoleTemplateBindingType = "rancher2_project_role_template_binding"
+)
 
+var (
+	testAccRancher2ProjectRoleTemplateBindingProject        string
+	testAccRancher2ProjectRoleTemplateBindingConfig         string
+	testAccRancher2ProjectRoleTemplateBindingUpdateConfig   string
+	testAccRancher2ProjectRoleTemplateBindingRecreateConfig string
+)
+
+func init() {
 	testAccRancher2ProjectRoleTemplateBindingProject = `
 resource "rancher2_project" "foo" {
   name = "foo"
-  cluster_id = "local"
+  cluster_id = "` + testAccRancher2ClusterID + `"
   description = "Terraform project role template binding acceptance test"
 }
 `
@@ -44,13 +53,12 @@ resource "rancher2_project_role_template_binding" "foo" {
   role_template_id = "project-member"
 }
  `
-)
+}
 
 func TestAccRancher2ProjectRoleTemplateBinding_basic(t *testing.T) {
 	var projectRole *managementClient.ProjectRoleTemplateBinding
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRancher2ProjectRoleTemplateBindingDestroy,
 		Steps: []resource.TestStep{
@@ -87,7 +95,6 @@ func TestAccRancher2ProjectRoleTemplateBinding_disappears(t *testing.T) {
 	var projectRole *managementClient.ProjectRoleTemplateBinding
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRancher2ProjectRoleTemplateBindingDestroy,
 		Steps: []resource.TestStep{

--- a/rancher2/resource_rancher2_project_test.go
+++ b/rancher2/resource_rancher2_project_test.go
@@ -224,13 +224,18 @@ func testAccCheckRancher2ProjectDestroy(s *terraform.State) error {
 			return err
 		}
 
-		_, err = client.Project.ByID(rs.Primary.ID)
+		obj, err := client.Project.ByID(rs.Primary.ID)
 		if err != nil {
 			if IsNotFound(err) {
 				return nil
 			}
 			return err
 		}
+
+		if obj.Removed != "" {
+			return nil
+		}
+
 		return fmt.Errorf("Project still exists")
 	}
 	return nil

--- a/rancher2/resource_rancher2_project_test.go
+++ b/rancher2/resource_rancher2_project_test.go
@@ -11,11 +11,20 @@ import (
 )
 
 const (
-	testAccRancher2ProjectType   = "rancher2_project"
+	testAccRancher2ProjectType = "rancher2_project"
+)
+
+var (
+	testAccRancher2ProjectConfig         string
+	testAccRancher2ProjectUpdateConfig   string
+	testAccRancher2ProjectRecreateConfig string
+)
+
+func init() {
 	testAccRancher2ProjectConfig = `
 resource "rancher2_project" "foo" {
   name = "foo"
-  cluster_id = "local"
+  cluster_id = "` + testAccRancher2ClusterID + `"
   description = "Terraform project acceptance test"
   resource_quota {
     project_limit {
@@ -35,7 +44,7 @@ resource "rancher2_project" "foo" {
 	testAccRancher2ProjectUpdateConfig = `
 resource "rancher2_project" "foo" {
   name = "foo-updated"
-  cluster_id = "local"
+  cluster_id = "` + testAccRancher2ClusterID + `"
   description = "Terraform project acceptance test - updated"
   resource_quota {
     project_limit {
@@ -55,7 +64,7 @@ resource "rancher2_project" "foo" {
 	testAccRancher2ProjectRecreateConfig = `
 resource "rancher2_project" "foo" {
   name = "foo"
-  cluster_id = "local"
+  cluster_id = "` + testAccRancher2ClusterID + `"
   description = "Terraform project acceptance test"
   resource_quota {
     project_limit {
@@ -71,13 +80,12 @@ resource "rancher2_project" "foo" {
   }
 }
  `
-)
+}
 
 func TestAccRancher2Project_basic(t *testing.T) {
 	var project *managementClient.Project
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRancher2ProjectDestroy,
 		Steps: []resource.TestStep{
@@ -87,7 +95,7 @@ func TestAccRancher2Project_basic(t *testing.T) {
 					testAccCheckRancher2ProjectExists(testAccRancher2ProjectType+".foo", project),
 					resource.TestCheckResourceAttr(testAccRancher2ProjectType+".foo", "name", "foo"),
 					resource.TestCheckResourceAttr(testAccRancher2ProjectType+".foo", "description", "Terraform project acceptance test"),
-					resource.TestCheckResourceAttr(testAccRancher2ProjectType+".foo", "cluster_id", "local"),
+					resource.TestCheckResourceAttr(testAccRancher2ProjectType+".foo", "cluster_id", testAccRancher2ClusterID),
 				),
 			},
 			resource.TestStep{
@@ -96,7 +104,7 @@ func TestAccRancher2Project_basic(t *testing.T) {
 					testAccCheckRancher2ProjectExists(testAccRancher2ProjectType+".foo", project),
 					resource.TestCheckResourceAttr(testAccRancher2ProjectType+".foo", "name", "foo-updated"),
 					resource.TestCheckResourceAttr(testAccRancher2ProjectType+".foo", "description", "Terraform project acceptance test - updated"),
-					resource.TestCheckResourceAttr(testAccRancher2ProjectType+".foo", "cluster_id", "local"),
+					resource.TestCheckResourceAttr(testAccRancher2ProjectType+".foo", "cluster_id", testAccRancher2ClusterID),
 				),
 			},
 			resource.TestStep{
@@ -105,7 +113,7 @@ func TestAccRancher2Project_basic(t *testing.T) {
 					testAccCheckRancher2ProjectExists(testAccRancher2ProjectType+".foo", project),
 					resource.TestCheckResourceAttr(testAccRancher2ProjectType+".foo", "name", "foo"),
 					resource.TestCheckResourceAttr(testAccRancher2ProjectType+".foo", "description", "Terraform project acceptance test"),
-					resource.TestCheckResourceAttr(testAccRancher2ProjectType+".foo", "cluster_id", "local"),
+					resource.TestCheckResourceAttr(testAccRancher2ProjectType+".foo", "cluster_id", testAccRancher2ClusterID),
 				),
 			},
 		},
@@ -116,7 +124,6 @@ func TestAccRancher2Project_disappears(t *testing.T) {
 	var project *managementClient.Project
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRancher2ProjectDestroy,
 		Steps: []resource.TestStep{

--- a/rancher2/resource_rancher2_setting.go
+++ b/rancher2/resource_rancher2_setting.go
@@ -1,0 +1,321 @@
+package rancher2
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	managementClient "github.com/rancher/types/client/management/v3"
+)
+
+//Schemas
+
+func settingFields() map[string]*schema.Schema {
+	s := map[string]*schema.Schema{
+		"name": &schema.Schema{
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+		"value": &schema.Schema{
+			Type:     schema.TypeString,
+			Required: true,
+		},
+		"annotations": &schema.Schema{
+			Type:     schema.TypeMap,
+			Optional: true,
+			Computed: true,
+		},
+		"labels": &schema.Schema{
+			Type:     schema.TypeMap,
+			Optional: true,
+			Computed: true,
+		},
+	}
+
+	return s
+}
+
+// Flatteners
+
+func flattenSetting(d *schema.ResourceData, in *managementClient.Setting) error {
+	if in == nil {
+		return fmt.Errorf("[ERROR] flattening setting: Input setting is nil")
+	}
+
+	d.SetId(in.ID)
+
+	err := d.Set("name", in.Name)
+	if err != nil {
+		return err
+	}
+	err = d.Set("value", in.Value)
+	if err != nil {
+		return err
+	}
+	err = d.Set("annotations", toMapInterface(in.Annotations))
+	if err != nil {
+		return err
+	}
+	err = d.Set("labels", toMapInterface(in.Labels))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Expanders
+
+func expandSetting(in *schema.ResourceData) (*managementClient.Setting, error) {
+	obj := &managementClient.Setting{}
+	if in == nil {
+		return nil, fmt.Errorf("[ERROR] expanding setting: Input ResourceData is nil")
+	}
+
+	if v := in.Id(); len(v) > 0 {
+		obj.ID = v
+	}
+
+	obj.Name = in.Get("name").(string)
+	obj.Value = in.Get("value").(string)
+
+	if v, ok := in.Get("annotations").(map[string]interface{}); ok && len(v) > 0 {
+		obj.Annotations = toMapString(v)
+	}
+
+	if v, ok := in.Get("labels").(map[string]interface{}); ok && len(v) > 0 {
+		obj.Labels = toMapString(v)
+	}
+
+	return obj, nil
+}
+
+func resourceRancher2Setting() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceRancher2SettingCreate,
+		Read:   resourceRancher2SettingRead,
+		Update: resourceRancher2SettingUpdate,
+		Delete: resourceRancher2SettingDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceRancher2SettingImport,
+		},
+		Schema: settingFields(),
+	}
+}
+
+func resourceRancher2SettingCreate(d *schema.ResourceData, meta interface{}) error {
+	client, err := meta.(*Config).ManagementClient()
+	if err != nil {
+		return err
+	}
+
+	// Checking if setting already exist, updating if already exist. setting id = setting name
+	exist, err := client.Setting.ByID(d.Get("name").(string))
+	if err == nil {
+		d.SetId(exist.ID)
+		return resourceRancher2SettingUpdate(d, meta)
+	}
+	if err != nil {
+		if !IsNotFound(err) {
+			return err
+		}
+	}
+
+	setting, err := expandSetting(d)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[INFO] Creating Setting %s", setting.Name)
+
+	newSetting, err := client.Setting.Create(setting)
+	if err != nil {
+		return err
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"active"},
+		Target:     []string{"active"},
+		Refresh:    settingStateRefreshFunc(client, newSetting.ID),
+		Timeout:    10 * time.Minute,
+		Delay:      1 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+	_, waitErr := stateConf.WaitForState()
+	if waitErr != nil {
+		return fmt.Errorf(
+			"[ERROR] waiting for setting (%s) to be created: %s", newSetting.ID, waitErr)
+	}
+
+	err = flattenSetting(d, newSetting)
+	if err != nil {
+		return err
+	}
+
+	return resourceRancher2SettingRead(d, meta)
+}
+
+func resourceRancher2SettingRead(d *schema.ResourceData, meta interface{}) error {
+	name := d.Get("name").(string)
+	log.Printf("[INFO] Refreshing Rancher2 Setting ID %s", d.Id())
+
+	client, err := meta.(*Config).ManagementClient()
+	if err != nil {
+		return err
+	}
+
+	setting, err := client.Setting.ByID(name)
+	if err != nil {
+		if IsNotFound(err) {
+			log.Printf("[INFO] Setting ID %s not found.", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	err = flattenSetting(d, setting)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceRancher2SettingUpdate(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[INFO] Updating Setting ID %s", d.Id())
+	client, err := meta.(*Config).ManagementClient()
+	if err != nil {
+		return err
+	}
+
+	setting, err := client.Setting.ByID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	update := map[string]interface{}{
+		"value":       d.Get("value").(string),
+		"annotations": toMapString(d.Get("annotations").(map[string]interface{})),
+		"labels":      toMapString(d.Get("labels").(map[string]interface{})),
+	}
+
+	newSetting, err := client.Setting.Update(setting, update)
+	if err != nil {
+		return err
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"active"},
+		Target:     []string{"active"},
+		Refresh:    settingStateRefreshFunc(client, newSetting.ID),
+		Timeout:    10 * time.Minute,
+		Delay:      1 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+	_, waitErr := stateConf.WaitForState()
+	if waitErr != nil {
+		return fmt.Errorf(
+			"[ERROR] waiting for setting (%s) to be updated: %s", newSetting.ID, waitErr)
+	}
+
+	return resourceRancher2SettingRead(d, meta)
+}
+
+func resourceRancher2SettingDelete(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[INFO] Deleting Setting ID %s", d.Id())
+	id := d.Id()
+	client, err := meta.(*Config).ManagementClient()
+	if err != nil {
+		return err
+	}
+
+	setting, err := client.Setting.ByID(id)
+	if err != nil {
+		if IsNotFound(err) {
+			log.Printf("[INFO] Setting ID %s not found.", id)
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	// Deleting setting if it was cretaed by user
+	if setting.CreatorID != "" {
+		err = client.Setting.Delete(setting)
+		if err != nil {
+			return fmt.Errorf("Error removing setting: %s", err)
+		}
+
+		log.Printf("[DEBUG] Waiting for setting (%s) to be removed", id)
+
+		stateConf := &resource.StateChangeConf{
+			Pending:    []string{"active"},
+			Target:     []string{"removed"},
+			Refresh:    settingStateRefreshFunc(client, id),
+			Timeout:    10 * time.Minute,
+			Delay:      1 * time.Second,
+			MinTimeout: 3 * time.Second,
+		}
+
+		_, waitErr := stateConf.WaitForState()
+		if waitErr != nil {
+			return fmt.Errorf(
+				"[ERROR] waiting for setting (%s) to be removed: %s", id, waitErr)
+		}
+		// Reseting setting to value = "" if it was cretaed by system
+	} else {
+		err = d.Set("value", "")
+		if err != nil {
+			return err
+		}
+
+		err = resourceRancher2SettingUpdate(d, meta)
+		if err != nil {
+			return err
+		}
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func resourceRancher2SettingImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	client, err := meta.(*Config).ManagementClient()
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+	setting, err := client.Setting.ByID(d.Id())
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+
+	err = flattenSetting(d, setting)
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+
+	return []*schema.ResourceData{d}, nil
+}
+
+// settingStateRefreshFunc returns a resource.StateRefreshFunc, used to watch a Rancher Project.
+func settingStateRefreshFunc(client *managementClient.Client, settingID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		obj, err := client.Setting.ByID(settingID)
+		if err != nil {
+			if IsNotFound(err) {
+				return obj, "removed", nil
+			}
+			return nil, "", err
+		}
+
+		if obj.Removed != "" {
+			return obj, "removed", nil
+		}
+
+		return obj, "active", nil
+	}
+}

--- a/rancher2/resource_rancher2_setting_test.go
+++ b/rancher2/resource_rancher2_setting_test.go
@@ -1,0 +1,188 @@
+package rancher2
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	managementClient "github.com/rancher/types/client/management/v3"
+)
+
+const (
+	testAccRancher2SettingType   = "rancher2_setting"
+	testAccRancher2SettingConfig = `
+resource "rancher2_setting" "foo" {
+	name = "foo"
+	value = "Terraform setting acceptance test"
+}
+`
+
+	testAccRancher2SettingUpdateConfig = `
+resource "rancher2_setting" "foo" {
+	name = "foo"
+	value = "Terraform setting acceptance test - updated"
+}
+ `
+
+	testAccRancher2SettingRecreateConfig = `
+resource "rancher2_setting" "foo" {
+	name = "foo"
+	value = "Terraform setting acceptance test"
+}
+ `
+)
+
+func TestAccRancher2Setting_basic(t *testing.T) {
+	var setting *managementClient.Setting
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRancher2SettingDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRancher2SettingConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2SettingExists(testAccRancher2SettingType+".foo", setting),
+					resource.TestCheckResourceAttr(testAccRancher2SettingType+".foo", "name", "foo"),
+					resource.TestCheckResourceAttr(testAccRancher2SettingType+".foo", "value", "Terraform setting acceptance test"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccRancher2SettingUpdateConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2SettingExists(testAccRancher2SettingType+".foo", setting),
+					resource.TestCheckResourceAttr(testAccRancher2SettingType+".foo", "name", "foo"),
+					resource.TestCheckResourceAttr(testAccRancher2SettingType+".foo", "value", "Terraform setting acceptance test - updated"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccRancher2SettingRecreateConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2SettingExists(testAccRancher2SettingType+".foo", setting),
+					resource.TestCheckResourceAttr(testAccRancher2SettingType+".foo", "name", "foo"),
+					resource.TestCheckResourceAttr(testAccRancher2SettingType+".foo", "value", "Terraform setting acceptance test"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRancher2Setting_disappears(t *testing.T) {
+	var setting *managementClient.Setting
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRancher2SettingDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRancher2SettingConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2SettingExists(testAccRancher2SettingType+".foo", setting),
+					testAccRancher2SettingDisappears(setting),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccRancher2SettingDisappears(setting *managementClient.Setting) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != testAccRancher2SettingType {
+				continue
+			}
+			client, err := testAccProvider.Meta().(*Config).ManagementClient()
+			if err != nil {
+				return err
+			}
+
+			setting, err = client.Setting.ByID(rs.Primary.ID)
+			if err != nil {
+				if IsNotFound(err) {
+					return nil
+				}
+				return err
+			}
+
+			err = client.Setting.Delete(setting)
+			if err != nil {
+				return fmt.Errorf("Error removing Setting: %s", err)
+			}
+
+			stateConf := &resource.StateChangeConf{
+				Pending:    []string{"active"},
+				Target:     []string{"removed"},
+				Refresh:    settingStateRefreshFunc(client, setting.ID),
+				Timeout:    10 * time.Minute,
+				Delay:      1 * time.Second,
+				MinTimeout: 3 * time.Second,
+			}
+
+			_, waitErr := stateConf.WaitForState()
+			if waitErr != nil {
+				return fmt.Errorf(
+					"[ERROR] waiting for setting (%s) to be removed: %s", setting.ID, waitErr)
+			}
+		}
+		return nil
+
+	}
+}
+
+func testAccCheckRancher2SettingExists(n string, setting *managementClient.Setting) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No setting ID is set")
+		}
+
+		client, err := testAccProvider.Meta().(*Config).ManagementClient()
+		if err != nil {
+			return err
+		}
+
+		foundSetting, err := client.Setting.ByID(rs.Primary.ID)
+		if err != nil {
+			if IsNotFound(err) {
+				return fmt.Errorf("Setting not found")
+			}
+			return err
+		}
+
+		setting = foundSetting
+
+		return nil
+	}
+}
+
+func testAccCheckRancher2SettingDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != testAccRancher2SettingType {
+			continue
+		}
+		client, err := testAccProvider.Meta().(*Config).ManagementClient()
+		if err != nil {
+			return err
+		}
+
+		_, err = client.Setting.ByID(rs.Primary.ID)
+		if err != nil {
+			if IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+		return fmt.Errorf("Setting still exists")
+	}
+	return nil
+}

--- a/scripts/ci
+++ b/scripts/ci
@@ -4,6 +4,7 @@ set -e
 cd $(dirname $0)
 
 ./build
-./test
 ./validate
+./test
+./testacc
 ./package

--- a/scripts/cleanup_rancher
+++ b/scripts/cleanup_rancher
@@ -1,4 +1,15 @@
 #!/bin/bash
 
 set -x
-rke rm --dind --config /tmp/rke_cluster.yml
+
+if [ -f /tmp/testacc_docker_id ]; then
+	echo Cleaning up rancher server docker
+	docker rm -fv $(cat /tmp/testacc_docker_id)
+	rm /tmp/testacc_docker_id
+fi
+
+if [ -f /tmp/rke_cluster.yml ]; then
+	echo Cleaning up rke dind cluster
+	rke remove --dind --force --config /tmp/rke_cluster.yml
+	rm /tmp/rke_cluster.yml
+fi

--- a/scripts/start_rancher
+++ b/scripts/start_rancher
@@ -1,9 +1,13 @@
 #!/bin/bash
 
 set -x
-server=$(docker run -d -p 8443:443 rancher/rancher:latest)
+server_port=44443
+server=$(docker run -d -p ${server_port}:443 rancher/rancher:latest)
 server_ip=$(docker inspect ${server} -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
+echo ${server} >>/tmp/testacc_docker_id
 export RANCHER_URL=https://${server_ip}
+export RANCHER_ACC_CLUSTER_NAME=bootstrap-imported-rke-cluster
+export RANCHER_INSECURE=true
 
 cat<<EOF>>/tmp/rke_cluster.yml
 ingress:
@@ -20,7 +24,7 @@ docker ps
 rke up --config /tmp/rke_cluster.yml --dind
 export KUBECONFIG="/tmp/kube_config_rke_cluster.yml"
 
-password=$(docker exec -it ${server} reset-password | grep -v '^New'|tr -d '\r')
+password=$(docker exec -i ${server} reset-password | grep -v '^New'|tr -d '\r')
 
 USERTOKEN=$(curl -X POST -k "${RANCHER_URL}/v3-public/localProviders/local?action=login" \
     -H 'Accept: application/json' \
@@ -33,15 +37,15 @@ curl -X PUT -k "${RANCHER_URL}/v3/settings/server-url" \
     -H 'Content-Type: application/json' \
     --data-binary "{\"name\": \"server-url\", \"value\":\"${RANCHER_URL}\"}"
 
-read -r cluster_json << EOM
+cluster_json=$(cat <<-EOM
 {
   "type": "cluster",
   "dockerRootDir": "/var/lib/docker",
   "enableNetworkPolicy": "false",
-  "name": "bootstrap-imported-rke-cluster"
+  "name": "${RANCHER_ACC_CLUSTER_NAME}"
 }
 EOM
-echo READ EXIT: $?
+)
 
 cluster_obj=$(curl -sk -X POST -H "Authorization: Bearer ${USERTOKEN}" \
     -H 'Accept: application/json' \
@@ -73,6 +77,4 @@ api_keys=$(curl -sSk \
   -H "Authorization: Bearer ${USERTOKEN}" \
   --data-binary '{"type":"token","description":"automation","name":""}')
 
-export RANCHER_ACCESS_KEY=$(echo ${api_keys} | jq -r '.token' | cut -d":" -f1)
-export RANCHER_SECRET_KEY=$(echo ${api_keys} | jq -r '.token' | cut -d":" -f2)
 export RANCHER_TOKEN_KEY=$(echo ${api_keys} | jq -r '.token')

--- a/scripts/testacc
+++ b/scripts/testacc
@@ -1,18 +1,22 @@
 #!/bin/bash
 set -e
 
+current_dir=$(pwd)
+
 cleanup()
 {
-    $(dirname $0)/cleanup_rancher
+    ${current_dir}/cleanup_rancher
 }
 trap cleanup EXIT TERM ERR
 
-$(dirname $0)/start_rancher
+source $(dirname $0)/start_rancher
 
 RANCHER_URL=${RANCHER_URL:-""}
 RANCHER_TOKEN_KEY=${RANCHER_TOKEN_KEY:-""}
 RANCHER_ACCESS_KEY=${RANCHER_ACCESS_KEY:-""}
 RANCHER_SECRET_KEY=${RANCHER_SECRET_KEY:-""}
+RANCHER_INSECURE=${RANCHER_INSECURE:-"false"}
+RANCHER_ACC_CLUSTER_NAME=${RANCHER_ACC_CLUSTER_NAME:-"local"}
 
 cd $(dirname $0)/..
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -29,8 +29,10 @@ provider "rancher2" {
 The following arguments are supported:
 
 * `api_url` - (Required) Rancher API url. It must be provided, but it can also be sourced from the `RANCHER_URL` environment variable.
-* `access_key` - (Optional) Rancher API access key. It can also be sourced from the `RANCHER_ACCESS_KEY` environment variable.
-* `secret_key` - (Optional) Rancher API secret key. It can also be sourced from the `RANCHER_SECRET_KEY` environment variable.
-* `token_key` - (Optional) Rancher API toke key. It can also be sourced from the `RANCHER_TOKEN_KEY` environment variable. Could be used instead `access_key` and `secret_key`.
-* `ca_certs` - CA certificates used to sign rancher server tls certificates. Mandatory if self signed.
-* `config` - Path to the Rancher client cli.json config file.
+* `access_key` - (Optional) Rancher API access key to connect to rancher. It can also be sourced from the `RANCHER_ACCESS_KEY` environment variable.
+* `secret_key` - (Optional) Rancher API secret key to connect to rancher. It can also be sourced from the `RANCHER_SECRET_KEY` environment variable.
+* `token_key` - (Optional) Rancher API token key to connect to rancher. It can also be sourced from the `RANCHER_TOKEN_KEY` environment variable. Could be used instead `access_key` and `secret_key`.
+* `ca_certs` - CA certificates used to sign rancher server tls certificates. Mandatory if self signed tls and insecure option false. It can also be sourced from the `RANCHER_CA_CERTS` environment variable.
+* `insecure` - (Optional) Allow insecure connection to Rancher. Mandatory if self signed tls and not ca_certs provided. It can also be sourced from the `RANCHER_INSECURE` environment variable.
+
+

--- a/website/docs/r/cluster.html.markdown
+++ b/website/docs/r/cluster.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "rancher2"
 page_title: "Rancher2: rancher2_cluster"
-sidebar_current: "docs-rancher2-cluster"
+sidebar_current: "docs-rancher2-resource-cluster"
 description: |-
   Provides a Rancher v2 Cluster resource. This can be used to create Clusters for rancher v2 environments and retrieve their information.
 ---

--- a/website/docs/r/namespace.html.markdown
+++ b/website/docs/r/namespace.html.markdown
@@ -33,7 +33,7 @@ resource "rancher2_namespace" "foo" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the namespace.
-* `project_id` - (Required) The project id where assign namespace.
+* `project_id` - (Required) The project id where assign namespace. It's on the form `project_id=<cluster_id>:<id>`. Updating `<id>` part on same `<cluster_id>` namespace will be moved between projects.
 * `description` - (Optional) A namespace description.
 * `resource_quota` - (Optional) Resource quota for namespace. Rancher v2.1.x or higher 
 * `annotations` - (Optional/Computed) Annotations for Node Pool object (map)
@@ -85,3 +85,4 @@ Projects can be imported using the namespace ID in the format `<cluster_id>:<nam
 $ terraform import rancher2_namespace.foo <cluster_id>:<namespace_id>
 ```
 
+When you import a raw k8s namespace, `project_id=<cluster_id>`. It'll not be assigned to any project. To move it into a project, update `project_id=<cluster_id>:<id>`. Namespace move is only supported inside same `cluster_id`.

--- a/website/docs/r/setting.html.markdown
+++ b/website/docs/r/setting.html.markdown
@@ -1,0 +1,49 @@
+---
+layout: "rancher2"
+page_title: "Rancher2: rancher2_setting"
+sidebar_current: "docs-rancher2-resource-setting"
+description: |-
+  Provides a Rancher v2 Setting resource. This can be used to create settings for rancher v2 environments and retrieve their information.
+---
+
+# rancher2\_setting
+
+Provides a Rancher v2 Setting resource. This can be used to create settings for rancher v2 environments and retrieve their information.
+
+On create, if setting already exists, provider will import it and update its value.
+
+On destroy, if setting is a system setting like `server-url`, provider'll not delete it from Rancher, it'll just update setting value to default and remove it from tfstate. 
+
+## Example Usage
+
+```hcl
+# Create a new rancher2 Setting
+resource "rancher2_setting" "foo" {
+  name = "foo"
+  value = "<VALUE>"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the setting (string)
+* `value` - (Required) The value of the setting (string)
+* `annotations` - (Optional/Computed) Annotations for setting object (map)
+* `labels` - (Optional/Computed) Labels for setting object (map)
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - (Computed) The ID of the resource.
+
+## Import
+
+Setting can be imported using the rancher setting ID.
+
+```
+$ terraform import rancher2_setting.foo <setting_id>
+```
+

--- a/website/rancher2.erb
+++ b/website/rancher2.erb
@@ -22,31 +22,31 @@
         <li<%= sidebar_current("docs-rancher2-resource") %>>
           <a href="#">Resources</a>
           <ul class="nav nav-visible">
-            <li<%= sidebar_current("docs-rancher2-auth-config-activedirectory") %>>
+            <li<%= sidebar_current("docs-rancher2-resource-auth-config-activedirectory") %>>
               <a href="/docs/providers/rancher2/r/authConfigActiveDirectory.html">rancher2_auth_config_activedirectory</a>
             </li>
-            <li<%= sidebar_current("docs-rancher2-auth-config-adfs") %>>
+            <li<%= sidebar_current("docs-rancher2-resource-auth-config-adfs") %>>
               <a href="/docs/providers/rancher2/r/authConfigADFS.html">rancher2_auth_config_adfs</a>
             </li>
-            <li<%= sidebar_current("docs-rancher2-auth-config-azuread") %>>
+            <li<%= sidebar_current("docs-rancher2-resource-auth-config-azuread") %>>
               <a href="/docs/providers/rancher2/r/authConfigAzureAD.html">rancher2_auth_config_azuread</a>
             </li>
-            <li<%= sidebar_current("docs-rancher2-auth-config-freeipa") %>>
+            <li<%= sidebar_current("docs-rancher2-resource-auth-config-freeipa") %>>
               <a href="/docs/providers/rancher2/r/authConfigFreeIpa.html">rancher2_auth_config_freeipa</a>
             </li>
-            <li<%= sidebar_current("docs-rancher2-auth-config-github") %>>
+            <li<%= sidebar_current("docs-rancher2-resource-auth-config-github") %>>
               <a href="/docs/providers/rancher2/r/authConfigGithub.html">rancher2_auth_config_github</a>
             </li>
-            <li<%= sidebar_current("docs-rancher2-auth-config-openldap") %>>
+            <li<%= sidebar_current("docs-rancher2-resource-auth-config-openldap") %>>
               <a href="/docs/providers/rancher2/r/authConfigOpenLdap.html">rancher2_auth_config_openldap</a>
             </li>
-            <li<%= sidebar_current("docs-rancher2-auth-config-ping") %>>
+            <li<%= sidebar_current("docs-rancher2-resource-auth-config-ping") %>>
               <a href="/docs/providers/rancher2/r/authConfigPing.html">rancher2_auth_config_ping</a>
             </li>
             <li<%= sidebar_current("docs-rancher2-resource-catalog") %>>
               <a href="/docs/providers/rancher2/r/catalog.html">rancher2_catalog</a>
             </li>
-            <li<%= sidebar_current("docs-rancher2-cluster") %>>
+            <li<%= sidebar_current("docs-rancher2-resource-cluster") %>>
               <a href="/docs/providers/rancher2/r/cluster.html">rancher2_cluster</a>
             </li>
             <li<%= sidebar_current("docs-rancher2-resource-cluster_logging") %>>
@@ -58,10 +58,10 @@
             <li<%= sidebar_current("docs-rancher2-resource-namespace") %>>
               <a href="/docs/providers/rancher2/r/namespace.html">rancher2_namespace</a>
             </li>
-            <li<%= sidebar_current("docs-rancher2-node-driver") %>>
+            <li<%= sidebar_current("docs-rancher2-resource-node-driver") %>>
               <a href="/docs/providers/rancher2/r/nodeDriver.html">rancher2_node_driver</a>
             </li>
-            <li<%= sidebar_current("docs-rancher2-node-pool") %>>
+            <li<%= sidebar_current("docs-rancher2-resource-node-pool") %>>
               <a href="/docs/providers/rancher2/r/nodePool.html">rancher2_node_pool</a>
             </li>
             <li<%= sidebar_current("docs-rancher2-resource-project") %>>
@@ -72,6 +72,9 @@
             </li>
             <li<%= sidebar_current("docs-rancher2-resource-project_role_template_binding") %>>
               <a href="/docs/providers/rancher2/r/projectRole.html">rancher2_project_role_template_binding</a>
+            </li>
+            <li<%= sidebar_current("docs-rancher2-resource-setting") %>>
+              <a href="/docs/providers/rancher2/r/setting.html">rancher2_setting</a>
             </li>
           </ul>
         </li>


### PR DESCRIPTION
This PR includes:
- Updated dapper scripts to include acceptance tests with rke dind. 
- Added RANCHER_ACC_CLUSTER_NAME env variable to get dynamic cluster name for ATT.
- Removed config file on provider. 
- Added util functions.
- Added resource rancher2 setting. 
- Added namespace move between projects.
- Added insecure option on config.
- Added pagination on rancher2 list calls.
- Updated README and website docs.
- Updated resource node-driver messages and tests.