### PR TITLE
Add new fields for kubeproxy and kubelet fields in cluster config

### DIFF
--- a/rancher2/cluster_rke_config_services.go
+++ b/rancher2/cluster_rke_config_services.go
@@ -97,6 +97,11 @@ func kubeletFields() map[string]*schema.Schema {
 			Optional: true,
 			Computed: true,
 		},
+		"fail_swap_on": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Computed: true,
+		},
 	}
 	return s
 }
@@ -107,6 +112,14 @@ func kubeproxyFields() map[string]*schema.Schema {
 			Type:     schema.TypeMap,
 			Optional: true,
 			Computed: true,
+		},
+		"extra_binds": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Computed: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
 		},
 	}
 	return s

--- a/rancher2/cluster_rke_config_services.go
+++ b/rancher2/cluster_rke_config_services.go
@@ -116,7 +116,6 @@ func kubeproxyFields() map[string]*schema.Schema {
 		"extra_binds": {
 			Type:     schema.TypeList,
 			Optional: true,
-			Computed: true,
 			Elem: &schema.Schema{
 				Type: schema.TypeString,
 			},
@@ -274,6 +273,10 @@ func flattenKubeproxy(in *managementClient.KubeproxyService) ([]interface{}, err
 
 	if len(in.ExtraArgs) > 0 {
 		obj["extra_args"] = toMapInterface(in.ExtraArgs)
+	}
+
+	if len(in.ExtraBinds) > 0 {
+		obj["extra_binds"] = toArrayInterface(in.ExtraBinds)
 	}
 
 	return []interface{}{obj}, nil
@@ -435,6 +438,10 @@ func expandKubeproxy(p []interface{}) (*managementClient.KubeproxyService, error
 
 	if v, ok := in["extra_args"].(map[string]interface{}); ok && len(v) > 0 {
 		obj.ExtraArgs = toMapString(v)
+	}
+
+	if v, ok := in["extra_binds"].([]interface{}); ok && len(v) > 0 {
+		obj.ExtraBinds = toArrayString(v)
 	}
 
 	return obj, nil

--- a/rancher2/cluster_rke_config_services.go
+++ b/rancher2/cluster_rke_config_services.go
@@ -262,6 +262,8 @@ func flattenKubelet(in *managementClient.KubeletService) ([]interface{}, error) 
 		obj["extra_args"] = toMapInterface(in.ExtraArgs)
 	}
 
+	obj["fail_swap_on"] = in.FailSwapOn
+
 	return []interface{}{obj}, nil
 }
 
@@ -413,6 +415,10 @@ func expandKubelet(p []interface{}) (*managementClient.KubeletService, error) {
 		return obj, nil
 	}
 	in := p[0].(map[string]interface{})
+
+	if v, ok := in["fail_swap_on"].(bool); ok {
+		obj.FailSwapOn = v
+	}
 
 	if v, ok := in["cluster_dns_server"].(string); ok && len(v) > 0 {
 		obj.ClusterDNSServer = v

--- a/website/docs/r/cluster.html.markdown
+++ b/website/docs/r/cluster.html.markdown
@@ -309,6 +309,7 @@ The following arguments are supported for `kube_controller`:
 
 The following arguments are supported for `kubelet`:
 
+* `fail_swap_on` - (Optional/Computed) Enable or disable failing when swap on is not supported (bool)
 * `cluster_dns_server` - (Optional/Computed) Cluster DNS Server option for kubelet service (string)
 * `cluster_domain` - (Optional/Computed) Cluster Domain option for kubelet service (string)
 * `extra_args` - (Optional/Computed) Extra arguments for kubelet service (map)
@@ -316,6 +317,7 @@ The following arguments are supported for `kubelet`:
 The following arguments are supported for `kubeproxy`:
 
 * `extra_args` - (Optional/Computed) Extra arguments for kubeproxy service (map)
+* `extra_binds` - (Optional) Extra binds for kubeproxy service (list)
 
 ### Amazon `eks_config`
 


### PR DESCRIPTION
This PR aims to solve #29. The fields I want to add are:

```
kubelet:
- fail_swap_on: <bool>

kubeproxy:
  extra_binds:
  - <strings>
```

The `fail_swap_on` works fine, going to the cluster config as expected, but the `kubeproxy.extra_binds` doesn't.

This is the slice of the output of `terraform apply` that shows the fields I want to add:

```
rke_config.0.services.0.kubelet.0.fail_swap_on:                                                 "false"
rke_config.0.services.0.kubeproxy.#:                                                            "1"
rke_config.0.services.0.kubeproxy.0.extra_args.%:                                               "1"
rke_config.0.services.0.kubeproxy.0.extra_args.ipvs-scheduler:                                  "lc"
rke_config.0.services.0.kubeproxy.0.extra_binds.#:                                              "2"
rke_config.0.services.0.kubeproxy.0.extra_binds.0:                                              "/usr/lib/modules:/lib/modules"
rke_config.0.services.0.kubeproxy.0.extra_binds.1:                                              "/var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket"
rke_config.0.ssh_agent_auth:                                                                    "false"
```

But the `extra_binds` of `kubeproxy` are not appearing in the cluster config as expected, and no error message is shown as well. I'm going to dig the RKE API to find something related that can help me solve this issue. Any help is welcome

