### PR TITLE
Fix rke cluster cloud_provider_vsphere global, disk and network as optional and computed fields

### DIFF
--- a/rancher2/cluster_rke_config_cloud_provider_vsphere.go
+++ b/rancher2/cluster_rke_config_cloud_provider_vsphere.go
@@ -135,6 +135,7 @@ func vsphereCloudProviderFields() map[string]*schema.Schema {
 			Type:     schema.TypeList,
 			MaxItems: 1,
 			Optional: true,
+			Computed: true,
 			Elem: &schema.Resource{
 				Schema: vsphereDiskCloudProviderFields(),
 			},
@@ -143,6 +144,7 @@ func vsphereCloudProviderFields() map[string]*schema.Schema {
 			Type:     schema.TypeList,
 			MaxItems: 1,
 			Optional: true,
+			Computed: true,
 			Elem: &schema.Resource{
 				Schema: vsphereGlobalCloudProviderFields(),
 			},
@@ -151,6 +153,7 @@ func vsphereCloudProviderFields() map[string]*schema.Schema {
 			Type:     schema.TypeList,
 			MaxItems: 1,
 			Optional: true,
+			Computed: true,
 			Elem: &schema.Resource{
 				Schema: vsphereNetworkCloudProviderFields(),
 			},

--- a/website/docs/r/cluster.html.markdown
+++ b/website/docs/r/cluster.html.markdown
@@ -229,9 +229,9 @@ The following arguments are supported for `vsphere_cloud_provider`:
 
 * `virtual_center` - (Required) (List)
 * `workspace` - (Required)
-* `disk` - (Optional)
-* `global` - (Optional)
-* `network` - (Optional)
+* `disk` - (Optional/Computed)
+* `global` - (Optional/Computed)
+* `network` - (Optional/Computed)
 
 The following arguments are supported for `virtual_center`:
 


### PR DESCRIPTION
Fix issue https://github.com/rancher/terraform-provider-rancher2/issues/52