### PR TITLE
Fix auth config resources removing test on apply

### DIFF
--- a/rancher2/auth_config_ldap.go
+++ b/rancher2/auth_config_ldap.go
@@ -33,16 +33,6 @@ func authConfigLdapFields() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Required: true,
 		},
-		"username": {
-			Type:      schema.TypeString,
-			Required:  true,
-			Sensitive: true,
-		},
-		"password": {
-			Type:      schema.TypeString,
-			Required:  true,
-			Sensitive: true,
-		},
 		"certificate": {
 			Type:      schema.TypeString,
 			Optional:  true,

--- a/rancher2/config.go
+++ b/rancher2/config.go
@@ -348,6 +348,34 @@ func (c *Config) ClusterRegistrationTokenExist(id string) error {
 	return nil
 }
 
+func (c *Config) CheckAuthConfigEnabled(id string) error {
+	if id == "" {
+		return fmt.Errorf("Auth config id is nil")
+	}
+
+	client, err := c.ManagementClient()
+	if err != nil {
+		return err
+	}
+
+	listOpts := NewListOpts(nil)
+	auths, err := client.AuthConfig.List(listOpts)
+	if err != nil {
+		return err
+	}
+
+	for _, auth := range auths.Data {
+		if auth.Enabled {
+			if auth.ID != id && auth.ID != "local" {
+				return fmt.Errorf("%s provider is already enabled", auth.ID)
+			}
+		}
+	}
+
+	return nil
+
+}
+
 func (c *Config) GetAuthConfig(in *managementClient.AuthConfig) (interface{}, error) {
 	resp, err := getAuthConfigObject(in.Type)
 	if err != nil {

--- a/rancher2/resource_rancher2_auth_config_activedirectory_test.go
+++ b/rancher2/resource_rancher2_auth_config_activedirectory_test.go
@@ -1,0 +1,197 @@
+package rancher2
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	managementClient "github.com/rancher/types/client/management/v3"
+)
+
+const (
+	testAccRancher2AuthConfigActiveDirectoryType   = "rancher2_auth_config_activedirectory"
+	testAccRancher2AuthConfigActiveDirectoryConfig = `
+resource "rancher2_auth_config_activedirectory" "activedirectory" {
+  servers = ["ad.test.local"]
+  service_account_username = "XXXXXX"
+  service_account_password = "XXXXXXXXX"
+  user_search_base = "dc=test,dc=local"
+  port = 389
+  default_login_domain = "test"
+}
+`
+
+	testAccRancher2AuthConfigActiveDirectoryUpdateConfig = `
+resource "rancher2_auth_config_activedirectory" "activedirectory" {
+  servers = ["ad.test.local"]
+  service_account_username = "XXXXXX"
+  service_account_password = "XXXXXXXXX"
+  user_search_base = "dc=users,dc=test,dc=local"
+  port = 389
+  default_login_domain = "test-updated"
+}
+ `
+
+	testAccRancher2AuthConfigActiveDirectoryRecreateConfig = `
+resource "rancher2_auth_config_activedirectory" "activedirectory" {
+  servers = ["ad.test.local"]
+  service_account_username = "XXXXXX"
+  service_account_password = "XXXXXXXXX"
+  user_search_base = "dc=test,dc=local"
+  port = 389
+  default_login_domain = "test"
+}
+ `
+)
+
+func TestAccRancher2AuthConfigActiveDirectory_basic(t *testing.T) {
+	var authConfig *managementClient.AuthConfig
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRancher2AuthConfigActiveDirectoryDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRancher2AuthConfigActiveDirectoryConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2AuthConfigExists(testAccRancher2AuthConfigActiveDirectoryType+"."+ActiveDirectoryConfigName, authConfig),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigActiveDirectoryType+"."+ActiveDirectoryConfigName, "name", ActiveDirectoryConfigName),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigActiveDirectoryType+"."+ActiveDirectoryConfigName, "user_search_base", "dc=test,dc=local"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigActiveDirectoryType+"."+ActiveDirectoryConfigName, "default_login_domain", "test"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccRancher2AuthConfigActiveDirectoryUpdateConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2AuthConfigExists(testAccRancher2AuthConfigActiveDirectoryType+"."+ActiveDirectoryConfigName, authConfig),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigActiveDirectoryType+"."+ActiveDirectoryConfigName, "name", ActiveDirectoryConfigName),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigActiveDirectoryType+"."+ActiveDirectoryConfigName, "user_search_base", "dc=users,dc=test,dc=local"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigActiveDirectoryType+"."+ActiveDirectoryConfigName, "default_login_domain", "test-updated"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccRancher2AuthConfigActiveDirectoryRecreateConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2AuthConfigExists(testAccRancher2AuthConfigActiveDirectoryType+"."+ActiveDirectoryConfigName, authConfig),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigActiveDirectoryType+"."+ActiveDirectoryConfigName, "name", ActiveDirectoryConfigName),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigActiveDirectoryType+"."+ActiveDirectoryConfigName, "user_search_base", "dc=test,dc=local"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigActiveDirectoryType+"."+ActiveDirectoryConfigName, "default_login_domain", "test"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRancher2AuthConfigActiveDirectory_disappears(t *testing.T) {
+	var authConfig *managementClient.AuthConfig
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRancher2AuthConfigActiveDirectoryDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRancher2AuthConfigActiveDirectoryConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2AuthConfigExists(testAccRancher2AuthConfigActiveDirectoryType+"."+ActiveDirectoryConfigName, authConfig),
+					testAccRancher2AuthConfigDisappears(authConfig, testAccRancher2AuthConfigActiveDirectoryType),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccRancher2AuthConfigDisappears(auth *managementClient.AuthConfig, objType string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != objType {
+				continue
+			}
+			client, err := testAccProvider.Meta().(*Config).ManagementClient()
+			if err != nil {
+				return err
+			}
+
+			auth, err = client.AuthConfig.ByID(rs.Primary.ID)
+			if err != nil {
+				if IsNotFound(err) {
+					return nil
+				}
+				return err
+			}
+
+			if auth.Enabled == true {
+				err = client.Post(auth.Actions["disable"], nil, nil)
+				if err != nil {
+					return fmt.Errorf("[ERROR] Disabling Auth Config %s: %s", auth.ID, err)
+				}
+			}
+			return nil
+		}
+		return nil
+
+	}
+}
+
+func testAccCheckRancher2AuthConfigExists(n string, auth *managementClient.AuthConfig) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Auth Config ID is set")
+		}
+
+		client, err := testAccProvider.Meta().(*Config).ManagementClient()
+		if err != nil {
+			return err
+		}
+
+		foundReg, err := client.AuthConfig.ByID(rs.Primary.ID)
+		if err != nil {
+			if IsNotFound(err) {
+				return fmt.Errorf("Auth Config %s not found", ActiveDirectoryConfigName)
+			}
+			return err
+		}
+
+		auth = foundReg
+
+		return nil
+	}
+}
+
+func testAccCheckRancher2AuthConfigActiveDirectoryDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != testAccRancher2AuthConfigActiveDirectoryType {
+			continue
+		}
+		client, err := testAccProvider.Meta().(*Config).ManagementClient()
+		if err != nil {
+			return err
+		}
+
+		auth, err := client.AuthConfig.ByID(rs.Primary.ID)
+		if err != nil {
+			if IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+
+		if auth.Enabled == true {
+			err = client.Post(auth.Actions["disable"], nil, nil)
+			if err != nil {
+				return fmt.Errorf("[ERROR] Disabling Auth Config %s: %s", auth.ID, err)
+			}
+		}
+		return nil
+	}
+	return nil
+}

--- a/rancher2/resource_rancher2_auth_config_adfs_test.go
+++ b/rancher2/resource_rancher2_auth_config_adfs_test.go
@@ -1,0 +1,146 @@
+package rancher2
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	managementClient "github.com/rancher/types/client/management/v3"
+)
+
+const (
+	testAccRancher2AuthConfigADFSType   = "rancher2_auth_config_adfs"
+	testAccRancher2AuthConfigADFSConfig = `
+resource "rancher2_auth_config_adfs" "adfs" {
+  display_name_field = "givenname"
+  groups_field = "Group"
+  uid_field = "upn"
+  user_name_field = "name"
+  idp_metadata_content = "XXXXXXXX"
+  rancher_api_host = "https://RANCHER"
+  sp_cert = "XXXXXX"
+  sp_key = "XXXXXXXX"
+}
+`
+
+	testAccRancher2AuthConfigADFSUpdateConfig = `
+resource "rancher2_auth_config_adfs" "adfs" {
+  display_name_field = "givenname"
+  groups_field = "Group"
+  uid_field = "upn"
+  user_name_field = "name-updated"
+  idp_metadata_content = "YYYYYYYY"
+  rancher_api_host = "https://RANCHER-UPDATED"
+  sp_cert = "XXXXXX"
+  sp_key = "YYYYYYYY"
+}
+ `
+
+	testAccRancher2AuthConfigADFSRecreateConfig = `
+resource "rancher2_auth_config_adfs" "adfs" {
+  display_name_field = "givenname"
+  groups_field = "Group"
+  uid_field = "upn"
+  user_name_field = "name"
+  idp_metadata_content = "XXXXXXXX"
+  rancher_api_host = "https://RANCHER"
+  sp_cert = "XXXXXX"
+  sp_key = "XXXXXXXX"
+}
+ `
+)
+
+func TestAccRancher2AuthConfigADFS_basic(t *testing.T) {
+	var authConfig *managementClient.AuthConfig
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRancher2AuthConfigADFSDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRancher2AuthConfigADFSConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2AuthConfigExists(testAccRancher2AuthConfigADFSType+"."+ADFSConfigName, authConfig),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigADFSType+"."+ADFSConfigName, "name", ADFSConfigName),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigADFSType+"."+ADFSConfigName, "user_name_field", "name"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigADFSType+"."+ADFSConfigName, "rancher_api_host", "https://RANCHER"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigADFSType+"."+ADFSConfigName, "sp_key", "XXXXXXXX"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigADFSType+"."+ADFSConfigName, "idp_metadata_content", "XXXXXXXX"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccRancher2AuthConfigADFSUpdateConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2AuthConfigExists(testAccRancher2AuthConfigADFSType+"."+ADFSConfigName, authConfig),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigADFSType+"."+ADFSConfigName, "name", ADFSConfigName),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigADFSType+"."+ADFSConfigName, "user_name_field", "name-updated"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigADFSType+"."+ADFSConfigName, "rancher_api_host", "https://RANCHER-UPDATED"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigADFSType+"."+ADFSConfigName, "sp_key", "YYYYYYYY"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigADFSType+"."+ADFSConfigName, "idp_metadata_content", "YYYYYYYY"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccRancher2AuthConfigADFSRecreateConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2AuthConfigExists(testAccRancher2AuthConfigADFSType+"."+ADFSConfigName, authConfig),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigADFSType+"."+ADFSConfigName, "name", ADFSConfigName),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigADFSType+"."+ADFSConfigName, "user_name_field", "name"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigADFSType+"."+ADFSConfigName, "rancher_api_host", "https://RANCHER"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigADFSType+"."+ADFSConfigName, "sp_key", "XXXXXXXX"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigADFSType+"."+ADFSConfigName, "idp_metadata_content", "XXXXXXXX"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRancher2AuthConfigADFS_disappears(t *testing.T) {
+	var authConfig *managementClient.AuthConfig
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRancher2AuthConfigADFSDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRancher2AuthConfigADFSConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2AuthConfigExists(testAccRancher2AuthConfigADFSType+"."+ADFSConfigName, authConfig),
+					testAccRancher2AuthConfigDisappears(authConfig, testAccRancher2AuthConfigADFSType),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckRancher2AuthConfigADFSDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != testAccRancher2AuthConfigADFSType {
+			continue
+		}
+		client, err := testAccProvider.Meta().(*Config).ManagementClient()
+		if err != nil {
+			return err
+		}
+
+		auth, err := client.AuthConfig.ByID(rs.Primary.ID)
+		if err != nil {
+			if IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+
+		if auth.Enabled == true {
+			err = client.Post(auth.Actions["disable"], nil, nil)
+			if err != nil {
+				return fmt.Errorf("[ERROR] Disabling Auth Config %s: %s", auth.ID, err)
+			}
+		}
+		return nil
+	}
+	return nil
+}

--- a/rancher2/resource_rancher2_auth_config_azuread_test.go
+++ b/rancher2/resource_rancher2_auth_config_azuread_test.go
@@ -1,0 +1,143 @@
+package rancher2
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	managementClient "github.com/rancher/types/client/management/v3"
+)
+
+const (
+	testAccRancher2AuthConfigAzureADType   = "rancher2_auth_config_azuread"
+	testAccRancher2AuthConfigAzureADConfig = `
+resource "rancher2_auth_config_azuread" "azuread" {
+  application_id = "XXXXXX"
+  application_secret = "XXXXXXXX"
+  auth_endpoint = "authorize"
+  graph_endpoint = "graph"
+  rancher_url = "https://RANCHER"
+  tenant_id = "XXXXXXXX"
+  token_endpoint = "token"
+}
+`
+
+	testAccRancher2AuthConfigAzureADUpdateConfig = `
+resource "rancher2_auth_config_azuread" "azuread" {
+  application_id = "XXXXXX"
+  application_secret = "YYYYYYYY"
+  auth_endpoint = "authorize-updated"
+  graph_endpoint = "graph"
+  rancher_url = "https://RANCHER-UPDATED"
+  tenant_id = "YYYYYYYY"
+  token_endpoint = "token"
+}
+ `
+
+	testAccRancher2AuthConfigAzureADRecreateConfig = `
+resource "rancher2_auth_config_azuread" "azuread" {
+  application_id = "XXXXXX"
+  application_secret = "XXXXXXXX"
+  auth_endpoint = "authorize"
+  graph_endpoint = "graph"
+  rancher_url = "https://RANCHER"
+  tenant_id = "XXXXXXXX"
+  token_endpoint = "token"
+}
+ `
+)
+
+func TestAccRancher2AuthConfigAzureAD_basic(t *testing.T) {
+	var authConfig *managementClient.AuthConfig
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRancher2AuthConfigAzureADDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRancher2AuthConfigAzureADConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2AuthConfigExists(testAccRancher2AuthConfigAzureADType+"."+AzureADConfigName, authConfig),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigAzureADType+"."+AzureADConfigName, "name", AzureADConfigName),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigAzureADType+"."+AzureADConfigName, "auth_endpoint", "authorize"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigAzureADType+"."+AzureADConfigName, "rancher_url", "https://RANCHER"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigAzureADType+"."+AzureADConfigName, "application_secret", "XXXXXXXX"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigAzureADType+"."+AzureADConfigName, "tenant_id", "XXXXXXXX"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccRancher2AuthConfigAzureADUpdateConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2AuthConfigExists(testAccRancher2AuthConfigAzureADType+"."+AzureADConfigName, authConfig),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigAzureADType+"."+AzureADConfigName, "name", AzureADConfigName),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigAzureADType+"."+AzureADConfigName, "auth_endpoint", "authorize-updated"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigAzureADType+"."+AzureADConfigName, "rancher_url", "https://RANCHER-UPDATED"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigAzureADType+"."+AzureADConfigName, "application_secret", "YYYYYYYY"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigAzureADType+"."+AzureADConfigName, "tenant_id", "YYYYYYYY"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccRancher2AuthConfigAzureADRecreateConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2AuthConfigExists(testAccRancher2AuthConfigAzureADType+"."+AzureADConfigName, authConfig),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigAzureADType+"."+AzureADConfigName, "name", AzureADConfigName),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigAzureADType+"."+AzureADConfigName, "auth_endpoint", "authorize"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigAzureADType+"."+AzureADConfigName, "rancher_url", "https://RANCHER"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigAzureADType+"."+AzureADConfigName, "application_secret", "XXXXXXXX"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigAzureADType+"."+AzureADConfigName, "tenant_id", "XXXXXXXX"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRancher2AuthConfigAzureAD_disappears(t *testing.T) {
+	var authConfig *managementClient.AuthConfig
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRancher2AuthConfigAzureADDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRancher2AuthConfigAzureADConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2AuthConfigExists(testAccRancher2AuthConfigAzureADType+"."+AzureADConfigName, authConfig),
+					testAccRancher2AuthConfigDisappears(authConfig, testAccRancher2AuthConfigAzureADType),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckRancher2AuthConfigAzureADDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != testAccRancher2AuthConfigAzureADType {
+			continue
+		}
+		client, err := testAccProvider.Meta().(*Config).ManagementClient()
+		if err != nil {
+			return err
+		}
+
+		auth, err := client.AuthConfig.ByID(rs.Primary.ID)
+		if err != nil {
+			if IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+
+		if auth.Enabled == true {
+			err = client.Post(auth.Actions["disable"], nil, nil)
+			if err != nil {
+				return fmt.Errorf("[ERROR] Disabling Auth Config %s: %s", auth.ID, err)
+			}
+		}
+		return nil
+	}
+	return nil
+}

--- a/rancher2/resource_rancher2_auth_config_freeipa_test.go
+++ b/rancher2/resource_rancher2_auth_config_freeipa_test.go
@@ -1,0 +1,152 @@
+package rancher2
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	managementClient "github.com/rancher/types/client/management/v3"
+)
+
+const (
+	testAccRancher2AuthConfigFreeIpaType   = "rancher2_auth_config_freeipa"
+	testAccRancher2AuthConfigFreeIpaConfig = `
+resource "rancher2_auth_config_freeipa" "freeipa" {
+  servers = ["freeipa.test.local"]
+  service_account_distinguished_name = "uid=admin,dc=test,dc=local"
+  service_account_password = "XXXXXXXX"
+  user_search_base = "dc=test,dc=local"
+  port = 389
+  group_dn_attribute = "entrydn"
+  group_member_mapping_attribute = "member"
+  group_member_user_attribute = "entrydn"
+  group_object_class = "groupOfNames"
+  user_name_attribute = "givenName"
+}
+`
+
+	testAccRancher2AuthConfigFreeIpaUpdateConfig = `
+resource "rancher2_auth_config_freeipa" "freeipa" {
+  servers = ["freeipa.test.local"]
+  service_account_distinguished_name = "uid=admin,cn=users,dc=test,dc=local"
+  service_account_password = "YYYYYYYY"
+  user_search_base = "cn=users,dc=test,dc=local"
+  port = 389
+  group_dn_attribute = "entrydn"
+  group_member_mapping_attribute = "member"
+  group_member_user_attribute = "entrydn"
+  group_object_class = "groupOfNames"
+  user_name_attribute = "givenName-updated"
+}
+ `
+
+	testAccRancher2AuthConfigFreeIpaRecreateConfig = `
+resource "rancher2_auth_config_freeipa" "freeipa" {
+  servers = ["freeipa.test.local"]
+  service_account_distinguished_name = "uid=admin,dc=test,dc=local"
+  service_account_password = "XXXXXXXX"
+  user_search_base = "dc=test,dc=local"
+  port = 389
+  group_dn_attribute = "entrydn"
+  group_member_mapping_attribute = "member"
+  group_member_user_attribute = "entrydn"
+  group_object_class = "groupOfNames"
+  user_name_attribute = "givenName"
+}
+ `
+)
+
+func TestAccRancher2AuthConfigFreeIpa_basic(t *testing.T) {
+	var authConfig *managementClient.AuthConfig
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRancher2AuthConfigFreeIpaDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRancher2AuthConfigFreeIpaConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2AuthConfigExists(testAccRancher2AuthConfigFreeIpaType+"."+FreeIpaConfigName, authConfig),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigFreeIpaType+"."+FreeIpaConfigName, "name", FreeIpaConfigName),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigFreeIpaType+"."+FreeIpaConfigName, "user_name_attribute", "givenName"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigFreeIpaType+"."+FreeIpaConfigName, "service_account_distinguished_name", "uid=admin,dc=test,dc=local"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigFreeIpaType+"."+FreeIpaConfigName, "user_search_base", "dc=test,dc=local"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigFreeIpaType+"."+FreeIpaConfigName, "service_account_password", "XXXXXXXX"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccRancher2AuthConfigFreeIpaUpdateConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2AuthConfigExists(testAccRancher2AuthConfigFreeIpaType+"."+FreeIpaConfigName, authConfig),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigFreeIpaType+"."+FreeIpaConfigName, "name", FreeIpaConfigName),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigFreeIpaType+"."+FreeIpaConfigName, "user_name_attribute", "givenName-updated"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigFreeIpaType+"."+FreeIpaConfigName, "service_account_distinguished_name", "uid=admin,cn=users,dc=test,dc=local"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigFreeIpaType+"."+FreeIpaConfigName, "user_search_base", "cn=users,dc=test,dc=local"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigFreeIpaType+"."+FreeIpaConfigName, "service_account_password", "YYYYYYYY"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccRancher2AuthConfigFreeIpaRecreateConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2AuthConfigExists(testAccRancher2AuthConfigFreeIpaType+"."+FreeIpaConfigName, authConfig),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigFreeIpaType+"."+FreeIpaConfigName, "name", FreeIpaConfigName),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigFreeIpaType+"."+FreeIpaConfigName, "user_name_attribute", "givenName"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigFreeIpaType+"."+FreeIpaConfigName, "service_account_distinguished_name", "uid=admin,dc=test,dc=local"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigFreeIpaType+"."+FreeIpaConfigName, "user_search_base", "dc=test,dc=local"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigFreeIpaType+"."+FreeIpaConfigName, "service_account_password", "XXXXXXXX"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRancher2AuthConfigFreeIpa_disappears(t *testing.T) {
+	var authConfig *managementClient.AuthConfig
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRancher2AuthConfigFreeIpaDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRancher2AuthConfigFreeIpaConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2AuthConfigExists(testAccRancher2AuthConfigFreeIpaType+"."+FreeIpaConfigName, authConfig),
+					testAccRancher2AuthConfigDisappears(authConfig, testAccRancher2AuthConfigFreeIpaType),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckRancher2AuthConfigFreeIpaDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != testAccRancher2AuthConfigFreeIpaType {
+			continue
+		}
+		client, err := testAccProvider.Meta().(*Config).ManagementClient()
+		if err != nil {
+			return err
+		}
+
+		auth, err := client.AuthConfig.ByID(rs.Primary.ID)
+		if err != nil {
+			if IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+
+		if auth.Enabled == true {
+			err = client.Post(auth.Actions["disable"], nil, nil)
+			if err != nil {
+				return fmt.Errorf("[ERROR] Disabling Auth Config %s: %s", auth.ID, err)
+			}
+		}
+		return nil
+	}
+	return nil
+}

--- a/rancher2/resource_rancher2_auth_config_github_test.go
+++ b/rancher2/resource_rancher2_auth_config_github_test.go
@@ -1,0 +1,122 @@
+package rancher2
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	managementClient "github.com/rancher/types/client/management/v3"
+)
+
+const (
+	testAccRancher2AuthConfigGithubType   = "rancher2_auth_config_github"
+	testAccRancher2AuthConfigGithubConfig = `
+resource "rancher2_auth_config_github" "github" {
+  client_id = "XXXXXX"
+  client_secret = "XXXXXXXX"
+}
+`
+
+	testAccRancher2AuthConfigGithubUpdateConfig = `
+resource "rancher2_auth_config_github" "github" {
+  client_id = "YYYYYY"
+  client_secret = "YYYYYYYY"
+}
+ `
+
+	testAccRancher2AuthConfigGithubRecreateConfig = `
+resource "rancher2_auth_config_github" "github" {
+  client_id = "XXXXXX"
+  client_secret = "XXXXXXXX"
+}
+ `
+)
+
+func TestAccRancher2AuthConfigGithub_basic(t *testing.T) {
+	var authConfig *managementClient.AuthConfig
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRancher2AuthConfigGithubDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRancher2AuthConfigGithubConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2AuthConfigExists(testAccRancher2AuthConfigGithubType+"."+GithubConfigName, authConfig),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigGithubType+"."+GithubConfigName, "name", GithubConfigName),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigGithubType+"."+GithubConfigName, "client_id", "XXXXXX"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigGithubType+"."+GithubConfigName, "client_secret", "XXXXXXXX"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccRancher2AuthConfigGithubUpdateConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2AuthConfigExists(testAccRancher2AuthConfigGithubType+"."+GithubConfigName, authConfig),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigGithubType+"."+GithubConfigName, "name", GithubConfigName),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigGithubType+"."+GithubConfigName, "client_id", "YYYYYY"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigGithubType+"."+GithubConfigName, "client_secret", "YYYYYYYY"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccRancher2AuthConfigGithubRecreateConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2AuthConfigExists(testAccRancher2AuthConfigGithubType+"."+GithubConfigName, authConfig),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigGithubType+"."+GithubConfigName, "name", GithubConfigName),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigGithubType+"."+GithubConfigName, "client_id", "XXXXXX"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigGithubType+"."+GithubConfigName, "client_secret", "XXXXXXXX"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRancher2AuthConfigGithub_disappears(t *testing.T) {
+	var authConfig *managementClient.AuthConfig
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRancher2AuthConfigGithubDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRancher2AuthConfigGithubConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2AuthConfigExists(testAccRancher2AuthConfigGithubType+"."+GithubConfigName, authConfig),
+					testAccRancher2AuthConfigDisappears(authConfig, testAccRancher2AuthConfigGithubType),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckRancher2AuthConfigGithubDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != testAccRancher2AuthConfigGithubType {
+			continue
+		}
+		client, err := testAccProvider.Meta().(*Config).ManagementClient()
+		if err != nil {
+			return err
+		}
+
+		auth, err := client.AuthConfig.ByID(rs.Primary.ID)
+		if err != nil {
+			if IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+
+		if auth.Enabled == true {
+			err = client.Post(auth.Actions["disable"], nil, nil)
+			if err != nil {
+				return fmt.Errorf("[ERROR] Disabling Auth Config %s: %s", auth.ID, err)
+			}
+		}
+		return nil
+	}
+	return nil
+}

--- a/rancher2/resource_rancher2_auth_config_openldap_test.go
+++ b/rancher2/resource_rancher2_auth_config_openldap_test.go
@@ -1,0 +1,152 @@
+package rancher2
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	managementClient "github.com/rancher/types/client/management/v3"
+)
+
+const (
+	testAccRancher2AuthConfigOpenLdapType   = "rancher2_auth_config_openldap"
+	testAccRancher2AuthConfigOpenLdapConfig = `
+resource "rancher2_auth_config_openldap" "openldap" {
+  servers = ["openldap.test.local"]
+  service_account_distinguished_name = "uid=admin,dc=test,dc=local"
+  service_account_password = "XXXXXXXX"
+  user_search_base = "dc=test,dc=local"
+  port = 389
+  group_dn_attribute = "entrydn"
+  group_member_mapping_attribute = "member"
+  group_member_user_attribute = "entrydn"
+  group_object_class = "groupOfNames"
+  user_name_attribute = "givenName"
+}
+`
+
+	testAccRancher2AuthConfigOpenLdapUpdateConfig = `
+resource "rancher2_auth_config_openldap" "openldap" {
+  servers = ["openldap.test.local"]
+  service_account_distinguished_name = "uid=admin,cn=users,dc=test,dc=local"
+  service_account_password = "YYYYYYYY"
+  user_search_base = "cn=users,dc=test,dc=local"
+  port = 389
+  group_dn_attribute = "entrydn"
+  group_member_mapping_attribute = "member"
+  group_member_user_attribute = "entrydn"
+  group_object_class = "groupOfNames"
+  user_name_attribute = "givenName-updated"
+}
+ `
+
+	testAccRancher2AuthConfigOpenLdapRecreateConfig = `
+resource "rancher2_auth_config_openldap" "openldap" {
+  servers = ["openldap.test.local"]
+  service_account_distinguished_name = "uid=admin,dc=test,dc=local"
+  service_account_password = "XXXXXXXX"
+  user_search_base = "dc=test,dc=local"
+  port = 389
+  group_dn_attribute = "entrydn"
+  group_member_mapping_attribute = "member"
+  group_member_user_attribute = "entrydn"
+  group_object_class = "groupOfNames"
+  user_name_attribute = "givenName"
+}
+ `
+)
+
+func TestAccRancher2AuthConfigOpenLdap_basic(t *testing.T) {
+	var authConfig *managementClient.AuthConfig
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRancher2AuthConfigOpenLdapDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRancher2AuthConfigOpenLdapConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2AuthConfigExists(testAccRancher2AuthConfigOpenLdapType+"."+OpenLdapConfigName, authConfig),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigOpenLdapType+"."+OpenLdapConfigName, "name", OpenLdapConfigName),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigOpenLdapType+"."+OpenLdapConfigName, "user_name_attribute", "givenName"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigOpenLdapType+"."+OpenLdapConfigName, "service_account_distinguished_name", "uid=admin,dc=test,dc=local"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigOpenLdapType+"."+OpenLdapConfigName, "user_search_base", "dc=test,dc=local"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigOpenLdapType+"."+OpenLdapConfigName, "service_account_password", "XXXXXXXX"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccRancher2AuthConfigOpenLdapUpdateConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2AuthConfigExists(testAccRancher2AuthConfigOpenLdapType+"."+OpenLdapConfigName, authConfig),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigOpenLdapType+"."+OpenLdapConfigName, "name", OpenLdapConfigName),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigOpenLdapType+"."+OpenLdapConfigName, "user_name_attribute", "givenName-updated"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigOpenLdapType+"."+OpenLdapConfigName, "service_account_distinguished_name", "uid=admin,cn=users,dc=test,dc=local"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigOpenLdapType+"."+OpenLdapConfigName, "user_search_base", "cn=users,dc=test,dc=local"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigOpenLdapType+"."+OpenLdapConfigName, "service_account_password", "YYYYYYYY"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccRancher2AuthConfigOpenLdapRecreateConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2AuthConfigExists(testAccRancher2AuthConfigOpenLdapType+"."+OpenLdapConfigName, authConfig),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigOpenLdapType+"."+OpenLdapConfigName, "name", OpenLdapConfigName),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigOpenLdapType+"."+OpenLdapConfigName, "user_name_attribute", "givenName"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigOpenLdapType+"."+OpenLdapConfigName, "service_account_distinguished_name", "uid=admin,dc=test,dc=local"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigOpenLdapType+"."+OpenLdapConfigName, "user_search_base", "dc=test,dc=local"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigOpenLdapType+"."+OpenLdapConfigName, "service_account_password", "XXXXXXXX"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRancher2AuthConfigOpenLdap_disappears(t *testing.T) {
+	var authConfig *managementClient.AuthConfig
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRancher2AuthConfigOpenLdapDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRancher2AuthConfigOpenLdapConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2AuthConfigExists(testAccRancher2AuthConfigOpenLdapType+"."+OpenLdapConfigName, authConfig),
+					testAccRancher2AuthConfigDisappears(authConfig, testAccRancher2AuthConfigOpenLdapType),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckRancher2AuthConfigOpenLdapDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != testAccRancher2AuthConfigOpenLdapType {
+			continue
+		}
+		client, err := testAccProvider.Meta().(*Config).ManagementClient()
+		if err != nil {
+			return err
+		}
+
+		auth, err := client.AuthConfig.ByID(rs.Primary.ID)
+		if err != nil {
+			if IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+
+		if auth.Enabled == true {
+			err = client.Post(auth.Actions["disable"], nil, nil)
+			if err != nil {
+				return fmt.Errorf("[ERROR] Disabling Auth Config %s: %s", auth.ID, err)
+			}
+		}
+		return nil
+	}
+	return nil
+}

--- a/rancher2/resource_rancher2_auth_config_ping_test.go
+++ b/rancher2/resource_rancher2_auth_config_ping_test.go
@@ -1,0 +1,146 @@
+package rancher2
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	managementClient "github.com/rancher/types/client/management/v3"
+)
+
+const (
+	testAccRancher2AuthConfigPingType   = "rancher2_auth_config_ping"
+	testAccRancher2AuthConfigPingConfig = `
+resource "rancher2_auth_config_ping" "ping" {
+  display_name_field = "displayName"
+  groups_field = "memberOf"
+  uid_field = "distinguishedName"
+  user_name_field = "sAMAccountName"
+  idp_metadata_content = "XXXXXXXX"
+  rancher_api_host = "https://RANCHER"
+  sp_cert = "XXXXXX"
+  sp_key = "XXXXXXXX"
+}
+`
+
+	testAccRancher2AuthConfigPingUpdateConfig = `
+resource "rancher2_auth_config_ping" "ping" {
+  display_name_field = "displayName"
+  groups_field = "memberOf"
+  uid_field = "distinguishedName"
+  user_name_field = "sAMAccountName-updated"
+  idp_metadata_content = "YYYYYYYY"
+  rancher_api_host = "https://RANCHER-UPDATED"
+  sp_cert = "XXXXXX"
+  sp_key = "YYYYYYYY"
+}
+ `
+
+	testAccRancher2AuthConfigPingRecreateConfig = `
+resource "rancher2_auth_config_ping" "ping" {
+  display_name_field = "displayName"
+  groups_field = "memberOf"
+  uid_field = "distinguishedName"
+  user_name_field = "sAMAccountName"
+  idp_metadata_content = "XXXXXXXX"
+  rancher_api_host = "https://RANCHER"
+  sp_cert = "XXXXXX"
+  sp_key = "XXXXXXXX"
+}
+ `
+)
+
+func TestAccRancher2AuthConfigPing_basic(t *testing.T) {
+	var authConfig *managementClient.AuthConfig
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRancher2AuthConfigPingDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRancher2AuthConfigPingConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2AuthConfigExists(testAccRancher2AuthConfigPingType+"."+PingConfigName, authConfig),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigPingType+"."+PingConfigName, "name", PingConfigName),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigPingType+"."+PingConfigName, "user_name_field", "sAMAccountName"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigPingType+"."+PingConfigName, "rancher_api_host", "https://RANCHER"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigPingType+"."+PingConfigName, "sp_key", "XXXXXXXX"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigPingType+"."+PingConfigName, "idp_metadata_content", "XXXXXXXX"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccRancher2AuthConfigPingUpdateConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2AuthConfigExists(testAccRancher2AuthConfigPingType+"."+PingConfigName, authConfig),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigPingType+"."+PingConfigName, "name", PingConfigName),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigPingType+"."+PingConfigName, "user_name_field", "sAMAccountName-updated"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigPingType+"."+PingConfigName, "rancher_api_host", "https://RANCHER-UPDATED"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigPingType+"."+PingConfigName, "sp_key", "YYYYYYYY"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigPingType+"."+PingConfigName, "idp_metadata_content", "YYYYYYYY"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccRancher2AuthConfigPingRecreateConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2AuthConfigExists(testAccRancher2AuthConfigPingType+"."+PingConfigName, authConfig),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigPingType+"."+PingConfigName, "name", PingConfigName),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigPingType+"."+PingConfigName, "user_name_field", "sAMAccountName"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigPingType+"."+PingConfigName, "rancher_api_host", "https://RANCHER"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigPingType+"."+PingConfigName, "sp_key", "XXXXXXXX"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigPingType+"."+PingConfigName, "idp_metadata_content", "XXXXXXXX"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRancher2AuthConfigPing_disappears(t *testing.T) {
+	var authConfig *managementClient.AuthConfig
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRancher2AuthConfigPingDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRancher2AuthConfigPingConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2AuthConfigExists(testAccRancher2AuthConfigPingType+"."+PingConfigName, authConfig),
+					testAccRancher2AuthConfigDisappears(authConfig, testAccRancher2AuthConfigPingType),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckRancher2AuthConfigPingDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != testAccRancher2AuthConfigPingType {
+			continue
+		}
+		client, err := testAccProvider.Meta().(*Config).ManagementClient()
+		if err != nil {
+			return err
+		}
+
+		auth, err := client.AuthConfig.ByID(rs.Primary.ID)
+		if err != nil {
+			if IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+
+		if auth.Enabled == true {
+			err = client.Post(auth.Actions["disable"], nil, nil)
+			if err != nil {
+				return fmt.Errorf("[ERROR] Disabling Auth Config %s: %s", auth.ID, err)
+			}
+		}
+		return nil
+	}
+	return nil
+}

--- a/website/docs/r/authConfigADFS.html.markdown
+++ b/website/docs/r/authConfigADFS.html.markdown
@@ -8,7 +8,9 @@ description: |-
 
 # rancher2\_auth\_config\_adfs
 
-Provides a Rancher v2 Auth Config ADFS resource. This can be used to configure and enable Auth Config ADFS for rancher v2 rke clusters and retrieve their information.
+Provides a Rancher v2 Auth Config ADFS resource. This can be used to configure and enable Auth Config ADFS for rancher v2 custom clusters and retrieve their information.
+
+Beside local, just one auth config provider could be enabled at once.
 
 ## Example Usage
 
@@ -16,10 +18,9 @@ Provides a Rancher v2 Auth Config ADFS resource. This can be used to configure a
 # Create a new rancher2 Auth Config ADFS
 resource "rancher2_auth_config_adfs" "adfs" {
   display_name_field = "<DISPLAY_NAME_FIELD>"
-  final_redirect_url = "<FINAL_REDIRECT_URL>"
   groups_field = "<GROUPS_FIELD>"
   idp_metadata_content = "<IDP_METADATA_CONTENT>"
-  rancher_api_host = "<RANCHER_API_HOST>"
+  rancher_api_host = "https://<RANCHER_API_HOST>"
   sp_cert = "<SP_CERT>"
   sp_key = "<SP_KEY>"
   uid_field = "<UID_FIELD>"
@@ -31,27 +32,26 @@ resource "rancher2_auth_config_adfs" "adfs" {
 
 The following arguments are supported:
 
-* `display_name_field` - (Required) ADFS display name field (string).
-* `final_redirect_url` - (Required) ADFS final redirect url (string).
-* `groups_field` - (Required) ADFS group field (string).
-* `idp_metadata_content` - (Required) ADFS IDP metadata content (string).
-* `rancher_api_host` - (Required) Rancher API host (string).
-* `sp_cert` - (Required/Sensitive) ADFS SP cert (string).
-* `sp_key` - (Required/Sensitive) ADFS SP key (string).
-* `uid_field` - (Required) ADFS UID field (string).
-* `user_name_field` - (Required) ADFS user name field (string).
-* `access_mode` - (Optional) Access mode for auth. `required`, `restricted`, `unrestricted` are supported. Default `unrestricted`
-* `allowed_principal_ids` - (Optional) Allowed principal ids for auth. Required if `access_mode` is `required` or `restricted`. Ex: `adfs_user://<USER_ID>`  `adfs_group://<GROUP_ID>`
-* `enabled` - (Optional) Enable auth config provider. Default `true`.
-* `annotations` - (Optional/Computed) Annotations of the resource (map).
-* `labels` - (Optional/Computed) Labels of the resource (map).
+* `display_name_field` - (Required) ADFS display name field (string)
+* `groups_field` - (Required) ADFS group field (string)
+* `idp_metadata_content` - (Required/Sensitive) ADFS IDP metadata content (string)
+* `rancher_api_host` - (Required) Rancher url. Schema needs to be specified, `https://<RANCHER_API_HOST>` (string)
+* `sp_cert` - (Required/Sensitive) ADFS SP cert (string)
+* `sp_key` - (Required/Sensitive) ADFS SP key (string)
+* `uid_field` - (Required) ADFS UID field (string)
+* `user_name_field` - (Required) ADFS user name field (string)
+* `access_mode` - (Optional) Access mode for auth. `required`, `restricted`, `unrestricted` are supported. Default `unrestricted` (string)
+* `allowed_principal_ids` - (Optional) Allowed principal ids for auth. Required if `access_mode` is `required` or `restricted`. Ex: `adfs_user://<USER_ID>`  `adfs_group://<GROUP_ID>` (list)
+* `enabled` - (Optional) Enable auth config provider. Default `true` (bool)
+* `annotations` - (Optional/Computed) Annotations of the resource (map)
+* `labels` - (Optional/Computed) Labels of the resource (map)
                 
 
 ## Attributes Reference
 
 The following attributes are exported:
 
-* `id` - (Computed) The ID of the resource.
-* `name` - (Computed) The name of the resource.
-* `type` - (Computed) The type of the resource.
+* `id` - (Computed) The ID of the resource (string)
+* `name` - (Computed) The name of the resource (string)
+* `type` - (Computed) The type of the resource (string)
 

--- a/website/docs/r/authConfigActiveDirectory.html.markdown
+++ b/website/docs/r/authConfigActiveDirectory.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides a Rancher v2 Auth Config ActiveDirectory resource. This can be used to configure and enable Auth Config ActiveDirectory for rancher v2 rke clusters and retrieve their information.
 
+Beside local, just one auth config provider could be enabled at once.
+
 ## Example Usage
 
 ```hcl
@@ -19,8 +21,6 @@ resource "rancher2_auth_config_activedirectory" "activedirectory" {
   service_account_username = "<SERVICE_DN>"
   service_account_password = "<SERVICE_PASSWORD>"
   user_search_base = "<SEARCH_BASE>"
-  username = "<TEST_USER>"
-  password = "<TEST_USER_PASSWORD>"
   port = <ACTIVEDIRECTORY_PORT>
 }
 ```
@@ -29,45 +29,43 @@ resource "rancher2_auth_config_activedirectory" "activedirectory" {
 
 The following arguments are supported:
 
-* `servers` - (Required) ActiveDirectory servers list ([]string).
-* `service_account_username` - (Required/Sensitive) Service account DN for access ActiveDirectory service (string).
-* `service_account_password` - (Required/Sensitive) Service account password for access ActiveDirectory service (string).
-* `user_search_base` - (Required) User search base DN (string).
-* `username` - (Required/Sensitive) User name to test ActiveDirectory access (string).
-* `password` - (Required/Sensitive) User password to test ActiveDirectory access (string).
-* `access_mode` - (Optional) Access mode for auth. `required`, `restricted`, `unrestricted` are supported. Default `unrestricted`
-* `allowed_principal_ids` - (Optional) Allowed principal ids for auth. Required if `access_mode` is `required` or `restricted`. Ex: `activedirectory_user://<DN>`  `activedirectory_group://<DN>`
-* `certificate` - (Optional/Sensitive) CA certificate for TLS if selfsigned (string).
-* `connection_timeout` - (Optional) ActiveDirectory connection timeout. Default `5000`
-* `default_login_domain` - (Optional) ActiveDirectory defult lgoin domain (string).
-* `enabled` - (Optional) Enable auth config provider. Default `true`.
-* `group_dn_attribute` - (Optional/Computed) Group DN attribute. Default `distinguishedName`.
-* `group_member_mapping_attribute` - (Optional/Computed) Group member mapping attribute. Default `member`.
-* `group_member_user_attribute` - (Optional/Computed) Group member user attribute. Default `distinguishedName`.
-* `group_name_attribute` - (Optional/Computed) Group name attribute. Default `name`.
-* `group_object_class` - (Optional/Computed) Group object class. Default `group`.
-* `group_search_attribute` - (Optional/Computed) Group search attribute. Default `sAMAccountName`.
-* `group_search_base` - (Optional/Computed) Group search base (string).
-* `group_search_filter` - (Optional/Computed) Group search filter (string).
-* `nested_group_membership_enabled` - (Optional/Computed) Nested group membership enable. Default `false`.
-* `port` - (Optional) ActiveDirectory port. Default `389`.
-* `user_disabled_bit_mask` - (Optional) User disabled bit mask. Default `2`.
+* `servers` - (Required) ActiveDirectory servers list (list)
+* `service_account_username` - (Required/Sensitive) Service account DN for access ActiveDirectory service (string)
+* `service_account_password` - (Required/Sensitive) Service account password for access ActiveDirectory service (string)
+* `user_search_base` - (Required) User search base DN (string)
+* `access_mode` - (Optional) Access mode for auth. `required`, `restricted`, `unrestricted` are supported. Default `unrestricted` (string)
+* `allowed_principal_ids` - (Optional) Allowed principal ids for auth. Required if `access_mode` is `required` or `restricted`. Ex: `activedirectory_user://<DN>`  `activedirectory_group://<DN>` (list)
+* `certificate` - (Optional/Sensitive) CA certificate for TLS if selfsigned (string)
+* `connection_timeout` - (Optional) ActiveDirectory connection timeout. Default `5000` (int)
+* `default_login_domain` - (Optional) ActiveDirectory defult lgoin domain (string)
+* `enabled` - (Optional) Enable auth config provider. Default `true` (bool)
+* `group_dn_attribute` - (Optional/Computed) Group DN attribute. Default `distinguishedName` (string)
+* `group_member_mapping_attribute` - (Optional/Computed) Group member mapping attribute. Default `member` (string)
+* `group_member_user_attribute` - (Optional/Computed) Group member user attribute. Default `distinguishedName` (string)
+* `group_name_attribute` - (Optional/Computed) Group name attribute. Default `name` (string)
+* `group_object_class` - (Optional/Computed) Group object class. Default `group` (string)
+* `group_search_attribute` - (Optional/Computed) Group search attribute. Default `sAMAccountName` (string)
+* `group_search_base` - (Optional/Computed) Group search base (string)
+* `group_search_filter` - (Optional/Computed) Group search filter (string)
+* `nested_group_membership_enabled` - (Optional/Computed) Nested group membership enable. Default `false` (bool)
+* `port` - (Optional) ActiveDirectory port. Default `389` (int)
+* `user_disabled_bit_mask` - (Optional) User disabled bit mask. Default `2` (int)
 * `user_enabled_attribute` - (Optional/Computed) User enable attribute (string)
-* `user_login_attribute` - (Optional/Computed) User login attribute. Default `sAMAccountName`.
-* `user_name_attribute` - (Optional/Computed) User name attribute. Default `name`.
-* `user_object_class` - (Optional/Computed) User object class. Default `person`.
-* `user_search_attribute` - (Optional/Computed) User search attribute. Default `sAMAccountName|sn|givenName`.
+* `user_login_attribute` - (Optional/Computed) User login attribute. Default `sAMAccountName` (string)
+* `user_name_attribute` - (Optional/Computed) User name attribute. Default `name` (string)
+* `user_object_class` - (Optional/Computed) User object class. Default `person` (string)
+* `user_search_attribute` - (Optional/Computed) User search attribute. Default `sAMAccountName|sn|givenName` (string)
 * `user_search_filter` - (Optional/Computed) User search filter (string)
-* `tls` - (Optional/Computed) Enable TLS connection (bool).
-* `annotations` - (Optional/Computed) Annotations of the resource (map).
-* `labels` - (Optional/Computed) Labels of the resource (map).
+* `tls` - (Optional/Computed) Enable TLS connection (bool)
+* `annotations` - (Optional/Computed) Annotations of the resource (map)
+* `labels` - (Optional/Computed) Labels of the resource (map)
                 
 
 ## Attributes Reference
 
 The following attributes are exported:
 
-* `id` - (Computed) The ID of the resource.
-* `name` - (Computed) The name of the resource.
-* `type` - (Computed) The type of the resource.
+* `id` - (Computed) The ID of the resource (string)
+* `name` - (Computed) The name of the resource (string)
+* `type` - (Computed) The type of the resource (string)
 

--- a/website/docs/r/authConfigAzureAD.html.markdown
+++ b/website/docs/r/authConfigAzureAD.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides a Rancher v2 Auth Config AzureAD resource. This can be used to configure and enable Auth Config AzureAD for rancher v2 rke clusters and retrieve their information.
 
+Beside local, just one auth config provider could be enabled at once.
+
 ## Example Usage
 
 ```hcl
@@ -18,7 +20,6 @@ resource "rancher2_auth_config_azuread" "azuread" {
   application_id = "<AZUREAD_APP_ID>"
   application_secret = "<AZUREAD_APP_SECRET>"
   auth_endpoint = "<AZUREAD_AUTH_ENDPOINT>"
-  code = "<AZUREAD_AUTH_CODE>"
   graph_endpoint = "<AZUREAD_GRAPH_ENDPOINT>"
   rancher_url = "<RANCHER_URL>"
   tenant_id = "<AZUREAD_TENANT_ID>"
@@ -30,28 +31,27 @@ resource "rancher2_auth_config_azuread" "azuread" {
 
 The following arguments are supported:
 
-* `application_id` - (Required/Sensitive) AzureAD auth application ID (string).
-* `application_secret` - (Required/Sensitive) AzureAD auth application secret (string).
-* `auth_endpoint` - (Required) AzureAD auth endpoint (string).
-* `code` - (Required/Sensitive) AzureAD auth code. Generated from `https://login.microsoftonline.com/<TENANT_ID>/oauth2/authorize?client_id=<APPLICATION_ID>&response_type=code` (string).
-* `graph_endpoint` - (Required) AzureAD graph endpoint (string).
-* `rancher_url` - (Required) Rancher URL (string).
-* `tenant_id` - (Required) AzureAD tenant ID (string).
-* `token_endpoint` - (Required) AzureAD token endpoint (string).
-* `endpoint` - (Optional) AzureAD endpoint. Default `https://login.microsoftonline.com/`.
-* `access_mode` - (Optional) Access mode for auth. `required`, `restricted`, `unrestricted` are supported. Default `unrestricted`
-* `allowed_principal_ids` - (Optional) Allowed principal ids for auth. Required if `access_mode` is `required` or `restricted`. Ex: `azuread_user://<USER_ID>`  `azuread_group://<GROUP_ID>`
-* `enabled` - (Optional) Enable auth config provider. Default `true`.
-* `tls` - (Optional) Enable TLS connection. Default `true`.
-* `annotations` - (Optional/Computed) Annotations of the resource (map).
-* `labels` - (Optional/Computed) Labels of the resource (map).
+* `application_id` - (Required/Sensitive) AzureAD auth application ID (string)
+* `application_secret` - (Required/Sensitive) AzureAD auth application secret (string)
+* `auth_endpoint` - (Required) AzureAD auth endpoint (string)
+* `graph_endpoint` - (Required) AzureAD graph endpoint (string)
+* `rancher_url` - (Required) Rancher URL (string)
+* `tenant_id` - (Required) AzureAD tenant ID (string)
+* `token_endpoint` - (Required) AzureAD token endpoint (string)
+* `endpoint` - (Optional) AzureAD endpoint. Default `https://login.microsoftonline.com/` (string)
+* `access_mode` - (Optional) Access mode for auth. `required`, `restricted`, `unrestricted` are supported. Default `unrestricted` (string)
+* `allowed_principal_ids` - (Optional) Allowed principal ids for auth. Required if `access_mode` is `required` or `restricted`. Ex: `azuread_user://<USER_ID>`  `azuread_group://<GROUP_ID>` (list)
+* `enabled` - (Optional) Enable auth config provider. Default `true` (bool)
+* `tls` - (Optional) Enable TLS connection. Default `true` (bool)
+* `annotations` - (Optional/Computed) Annotations of the resource (map)
+* `labels` - (Optional/Computed) Labels of the resource (map)
                 
 
 ## Attributes Reference
 
 The following attributes are exported:
 
-* `id` - (Computed) The ID of the resource.
-* `name` - (Computed) The name of the resource.
-* `type` - (Computed) The type of the resource.
+* `id` - (Computed) The ID of the resource (string)
+* `name` - (Computed) The name of the resource (string)
+* `type` - (Computed) The type of the resource (string)
 

--- a/website/docs/r/authConfigFreeIpa.html.markdown
+++ b/website/docs/r/authConfigFreeIpa.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides a Rancher v2 Auth Config FreeIpa resource. This can be used to configure and enable Auth Config FreeIpa for rancher v2 rke clusters and retrieve their information.
 
+Beside local, just one auth config provider could be enabled at once.
+
 ## Example Usage
 
 ```hcl
@@ -19,8 +21,6 @@ resource "rancher2_auth_config_freeipa" "freeipa" {
   service_account_distinguished_name = "<SERVICE_DN>"
   service_account_password = "<SERVICE_PASSWORD>"
   user_search_base = "<SEARCH_BASE>"
-  username = "<TEST_USER>"
-  password = "<TEST_USER_PASSWORD>"
   port = <FREEIPA_PORT>
 }
 ```
@@ -29,43 +29,41 @@ resource "rancher2_auth_config_freeipa" "freeipa" {
 
 The following arguments are supported:
 
-* `servers` - (Required) FreeIpa servers list ([]string).
-* `service_account_distinguished_name` - (Required/Sensitive) Service account DN for access FreeIpa service (string).
-* `service_account_password` - (Required/Sensitive) Service account password for access FreeIpa service (string).
-* `user_search_base` - (Required) User search base DN (string).
-* `username` - (Required/Sensitive) User name to test FreeIpa access (string).
-* `password` - (Required/Sensitive) User password to test FreeIpa access (string).
-* `access_mode` - (Optional) Access mode for auth. `required`, `restricted`, `unrestricted` are supported. Default `unrestricted`
-* `allowed_principal_ids` - (Optional) Allowed principal ids for auth. Required if `access_mode` is `required` or `restricted`. Ex: `freeipa_user://<DN>`  `freeipa_group://<DN>`
-* `certificate` - (Optional/Sensitive) CA certificate for TLS if selfsigned (string).
-* `connection_timeout` - (Optional) FreeIpa connection timeout. Default `5000`
-* `enabled` - (Optional) Enable auth config provider. Default `true`.
-* `group_dn_attribute` - (Optional/Computed) Group DN attribute. Default `entryDN`.
-* `group_member_mapping_attribute` - (Optional/Computed) Group member mapping attribute. Default `member`.
-* `group_member_user_attribute` - (Optional/Computed) Group member user attribute. Default `entryDN`.
-* `group_name_attribute` - (Optional/Computed) Group name attribute. Default `cn`.
-* `group_object_class` - (Optional/Computed) Group object class. Default `groupOfNames`.
-* `group_search_attribute` - (Optional/Computed) Group search attribute. Default `cn`.
-* `group_search_base` - (Optional/Computed) Group search base (string).
-* `nested_group_membership_enabled` - (Optional/Computed) Nested group membership enable. Default `false`.
-* `port` - (Optional) FreeIpa port. Default `389`.
-* `user_disabled_bit_mask` - (Optional/Computed) User disabled bit mask (int).
+* `servers` - (Required) FreeIpa servers list (list)
+* `service_account_distinguished_name` - (Required/Sensitive) Service account DN for access FreeIpa service (string)
+* `service_account_password` - (Required/Sensitive) Service account password for access FreeIpa service (string)
+* `user_search_base` - (Required) User search base DN (string)
+* `access_mode` - (Optional) Access mode for auth. `required`, `restricted`, `unrestricted` are supported. Default `unrestricted` (string)
+* `allowed_principal_ids` - (Optional) Allowed principal ids for auth. Required if `access_mode` is `required` or `restricted`. Ex: `freeipa_user://<DN>`  `freeipa_group://<DN>` (list)
+* `certificate` - (Optional/Sensitive) CA certificate for TLS if selfsigned (string)
+* `connection_timeout` - (Optional) FreeIpa connection timeout. Default `5000` (int)
+* `enabled` - (Optional) Enable auth config provider. Default `true` (bool)
+* `group_dn_attribute` - (Optional/Computed) Group DN attribute. Default `entryDN` (string)
+* `group_member_mapping_attribute` - (Optional/Computed) Group member mapping attribute. Default `member` (string)
+* `group_member_user_attribute` - (Optional/Computed) Group member user attribute. Default `entryDN` (string)
+* `group_name_attribute` - (Optional/Computed) Group name attribute. Default `cn` (string)
+* `group_object_class` - (Optional/Computed) Group object class. Default `groupOfNames` (string)
+* `group_search_attribute` - (Optional/Computed) Group search attribute. Default `cn` (string)
+* `group_search_base` - (Optional/Computed) Group search base (string)
+* `nested_group_membership_enabled` - (Optional/Computed) Nested group membership enable. Default `false` (bool)
+* `port` - (Optional) FreeIpa port. Default `389` (int)
+* `user_disabled_bit_mask` - (Optional/Computed) User disabled bit mask (int)
 * `user_enabled_attribute` - (Optional/Computed) User enable attribute (string)
-* `user_login_attribute` - (Optional/Computed) User login attribute. Default `uid`.
-* `user_member_attribute` - (Optional/Computed) User member attribute. Default `memberOf`.
-* `user_name_attribute` - (Optional/Computed) User name attribute. Default `givenName`.
-* `user_object_class` - (Optional/Computed) User object class. Default `inetorgperson`.
-* `user_search_attribute` - (Optional/Computed) User search attribute. Default `uid|sn|givenName`.
-* `tls` - (Optional/Computed) Enable TLS connection (bool).
-* `annotations` - (Optional/Computed) Annotations of the resource (map).
-* `labels` - (Optional/Computed) Labels of the resource (map).
+* `user_login_attribute` - (Optional/Computed) User login attribute. Default `uid` (string)
+* `user_member_attribute` - (Optional/Computed) User member attribute. Default `memberOf` (string)
+* `user_name_attribute` - (Optional/Computed) User name attribute. Default `givenName` (string)
+* `user_object_class` - (Optional/Computed) User object class. Default `inetorgperson` (string)
+* `user_search_attribute` - (Optional/Computed) User search attribute. Default `uid|sn|givenName` (string)
+* `tls` - (Optional/Computed) Enable TLS connection (bool)
+* `annotations` - (Optional/Computed) Annotations of the resource (map)
+* `labels` - (Optional/Computed) Labels of the resource (map)
                 
 
 ## Attributes Reference
 
 The following attributes are exported:
 
-* `id` - (Computed) The ID of the resource.
-* `name` - (Computed) The name of the resource.
-* `type` - (Computed) The type of the resource.
+* `id` - (Computed) The ID of the resource (string)
+* `name` - (Computed) The name of the resource (string)
+* `type` - (Computed) The type of the resource (string)
 

--- a/website/docs/r/authConfigGithub.html.markdown
+++ b/website/docs/r/authConfigGithub.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides a Rancher v2 Auth Config Github resource. This can be used to configure and enable Auth Config Github for rancher v2 rke clusters and retrieve their information.
 
+Beside local, just one auth config provider could be enabled at once.
+
 ## Example Usage
 
 ```hcl
@@ -17,7 +19,6 @@ Provides a Rancher v2 Auth Config Github resource. This can be used to configure
 resource "rancher2_auth_config_github" "github" {
   client_id = "<GITHUB_CLIENT_ID>"
   client_secret = "<GITHUB_CLIENT_SECRET>"
-  code = "<GITHUB_AUTH_CODE>"
 }
 ```
 
@@ -25,23 +26,22 @@ resource "rancher2_auth_config_github" "github" {
 
 The following arguments are supported:
 
-* `client_id` - (Required/Sensitive) Github auth Client ID (string).
-* `client_secret` - (Required/Sensitive) Github auth Client secret (string).
-* `code` - (Required/Sensitive) Github auth code. Generated from `https://github.com/login/oauth/authorize?client_id=<CLIENT_ID>` (string).
-* `hostname` - (Optional) Gtihub hostname to connect. Defaulf `github.com`.
-* `access_mode` - (Optional) Access mode for auth. `required`, `restricted`, `unrestricted` are supported. Default `unrestricted`
-* `allowed_principal_ids` - (Optional) Allowed principal ids for auth. Required if `access_mode` is `required` or `restricted`. Ex: `github_user://<USER_ID>`  `github_group://<GROUP_ID>`
-* `enabled` - (Optional) Enable auth config provider. Default `true`.
-* `tls` - (Optional) Enable TLS connection. Default `true`.
-* `annotations` - (Optional/Computed) Annotations of the resource (map).
-* `labels` - (Optional/Computed) Labels of the resource (map).
+* `client_id` - (Required/Sensitive) Github auth Client ID (string)
+* `client_secret` - (Required/Sensitive) Github auth Client secret (string)
+* `hostname` - (Optional) Gtihub hostname to connect. Defaulf `github.com` (string)
+* `access_mode` - (Optional) Access mode for auth. `required`, `restricted`, `unrestricted` are supported. Default `unrestricted` (string)
+* `allowed_principal_ids` - (Optional) Allowed principal ids for auth. Required if `access_mode` is `required` or `restricted`. Ex: `github_user://<USER_ID>`  `github_group://<GROUP_ID>` (list)
+* `enabled` - (Optional) Enable auth config provider. Default `true` (bool)
+* `tls` - (Optional) Enable TLS connection. Default `true` (bool)
+* `annotations` - (Optional/Computed) Annotations of the resource (map)
+* `labels` - (Optional/Computed) Labels of the resource (map)
                 
 
 ## Attributes Reference
 
 The following attributes are exported:
 
-* `id` - (Computed) The ID of the resource.
-* `name` - (Computed) The name of the resource.
-* `type` - (Computed) The type of the resource.
+* `id` - (Computed) The ID of the resource (string)
+* `name` - (Computed) The name of the resource (string)
+* `type` - (Computed) The type of the resource (string)
 

--- a/website/docs/r/authConfigOpenLdap.html.markdown
+++ b/website/docs/r/authConfigOpenLdap.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides a Rancher v2 Auth Config OpenLdap resource. This can be used to configure and enable Auth Config OpenLdap for rancher v2 rke clusters and retrieve their information.
 
+Beside local, just one auth config provider could be enabled at once.
+
 ## Example Usage
 
 ```hcl
@@ -19,8 +21,6 @@ resource "rancher2_auth_config_openldap" "openldap" {
   service_account_distinguished_name = "<SERVICE_DN>"
   service_account_password = "<SERVICE_PASSWORD>"
   user_search_base = "<SEARCH_BASE>"
-  username = "<TEST_USER>"
-  password = "<TEST_USER_PASSWORD>"
   port = <OPENLDAP_PORT>
 }
 ```
@@ -29,43 +29,41 @@ resource "rancher2_auth_config_openldap" "openldap" {
 
 The following arguments are supported:
 
-* `servers` - (Required) Openldap servers list ([]string).
-* `service_account_distinguished_name` - (Required/Sensitive) Service account DN for access openldap service (string).
-* `service_account_password` - (Required/Sensitive) Service account password for access openldap service (string).
-* `user_search_base` - (Required) User search base DN (string).
-* `username` - (Required/Sensitive) User name to test openldap access (string).
-* `password` - (Required/Sensitive) User password to test openldap access (string).
-* `access_mode` - (Optional) Access mode for auth. `required`, `restricted`, `unrestricted` are supported. Default `unrestricted`
-* `allowed_principal_ids` - (Optional) Allowed principal ids for auth. Required if `access_mode` is `required` or `restricted`. Ex: `openldap_user://<DN>`  `openldap_group://<DN>`
-* `certificate` - (Optional/Sensitive) CA certificate for TLS if selfsigned (string).
-* `connection_timeout` - (Optional) Openldap connection timeout. Default `5000`
-* `enabled` - (Optional) Enable auth config provider. Default `true`.
-* `group_dn_attribute` - (Optional/Computed) Group DN attribute. Default `entryDN`.
-* `group_member_mapping_attribute` - (Optional/Computed) Group member mapping attribute. Default `member`.
-* `group_member_user_attribute` - (Optional/Computed) Group member user attribute. Default `entryDN`.
-* `group_name_attribute` - (Optional/Computed) Group name attribute. Default `cn`.
-* `group_object_class` - (Optional/Computed) Group object class. Default `groupOfNames`.
-* `group_search_attribute` - (Optional/Computed) Group search attribute. Default `cn`.
-* `group_search_base` - (Optional/Computed) Group search base (string).
-* `nested_group_membership_enabled` - (Optional/Computed) Nested group membership enable. Default `false`.
-* `port` - (Optional) Openldap port. Default `389`.
-* `user_disabled_bit_mask` - (Optional/Computed) User disabled bit mask (int).
+* `servers` - (Required) Openldap servers list (list)
+* `service_account_distinguished_name` - (Required/Sensitive) Service account DN for access openldap service (string)
+* `service_account_password` - (Required/Sensitive) Service account password for access openldap service (string)
+* `user_search_base` - (Required) User search base DN (string)
+* `access_mode` - (Optional) Access mode for auth. `required`, `restricted`, `unrestricted` are supported. Default `unrestricted` (string)
+* `allowed_principal_ids` - (Optional) Allowed principal ids for auth. Required if `access_mode` is `required` or `restricted`. Ex: `openldap_user://<DN>`  `openldap_group://<DN>` (list)
+* `certificate` - (Optional/Sensitive) CA certificate for TLS if selfsigned (string)
+* `connection_timeout` - (Optional) Openldap connection timeout. Default `5000` (int)
+* `enabled` - (Optional) Enable auth config provider. Default `true` (bool)
+* `group_dn_attribute` - (Optional/Computed) Group DN attribute. Default `entryDN` (string)
+* `group_member_mapping_attribute` - (Optional/Computed) Group member mapping attribute. Default `member` (string)
+* `group_member_user_attribute` - (Optional/Computed) Group member user attribute. Default `entryDN` (string)
+* `group_name_attribute` - (Optional/Computed) Group name attribute. Default `cn` (string)
+* `group_object_class` - (Optional/Computed) Group object class. Default `groupOfNames` (string)
+* `group_search_attribute` - (Optional/Computed) Group search attribute. Default `cn` (string)
+* `group_search_base` - (Optional/Computed) Group search base (string)
+* `nested_group_membership_enabled` - (Optional/Computed) Nested group membership enable. Default `false` (bool)
+* `port` - (Optional) Openldap port. Default `389` (int)
+* `user_disabled_bit_mask` - (Optional/Computed) User disabled bit mask (int)
 * `user_enabled_attribute` - (Optional/Computed) User enable attribute (string)
-* `user_login_attribute` - (Optional/Computed) User login attribute. Default `uid`.
-* `user_member_attribute` - (Optional/Computed) User member attribute. Default `memberOf`.
-* `user_name_attribute` - (Optional/Computed) User name attribute. Default `givenName`.
-* `user_object_class` - (Optional/Computed) User object class. Default `inetorgperson`.
-* `user_search_attribute` - (Optional/Computed) User search attribute. Default `uid|sn|givenName`.
-* `tls` - (Optional/Computed) Enable TLS connection (bool).
-* `annotations` - (Optional/Computed) Annotations of the resource (map).
-* `labels` - (Optional/Computed) Labels of the resource (map).
+* `user_login_attribute` - (Optional/Computed) User login attribute. Default `uid` (string)
+* `user_member_attribute` - (Optional/Computed) User member attribute. Default `memberOf` (string)
+* `user_name_attribute` - (Optional/Computed) User name attribute. Default `givenName` (string)
+* `user_object_class` - (Optional/Computed) User object class. Default `inetorgperson` (string)
+* `user_search_attribute` - (Optional/Computed) User search attribute. Default `uid|sn|givenName` (string)
+* `tls` - (Optional/Computed) Enable TLS connection (bool)
+* `annotations` - (Optional/Computed) Annotations of the resource (map)
+* `labels` - (Optional/Computed) Labels of the resource (map)
                 
 
 ## Attributes Reference
 
 The following attributes are exported:
 
-* `id` - (Computed) The ID of the resource.
-* `name` - (Computed) The name of the resource.
-* `type` - (Computed) The type of the resource.
+* `id` - (Computed) The ID of the resource (string)
+* `name` - (Computed) The name of the resource (string)
+* `type` - (Computed) The type of the resource (string)
 

--- a/website/docs/r/authConfigPing.html.markdown
+++ b/website/docs/r/authConfigPing.html.markdown
@@ -10,16 +10,17 @@ description: |-
 
 Provides a Rancher v2 Auth Config Ping resource. This can be used to configure and enable Auth Config Ping for rancher v2 rke clusters and retrieve their information.
 
+Beside local, just one auth config provider could be enabled at once.
+
 ## Example Usage
 
 ```hcl
 # Create a new rancher2 Auth Config Ping
 resource "rancher2_auth_config_ping" "ping" {
   display_name_field = "<DISPLAY_NAME_FIELD>"
-  final_redirect_url = "<FINAL_REDIRECT_URL>"
   groups_field = "<GROUPS_FIELD>"
   idp_metadata_content = "<IDP_METADATA_CONTENT>"
-  rancher_api_host = "<RANCHER_API_HOST>"
+  rancher_api_host = "https://<RANCHER_API_HOST>"
   sp_cert = "<SP_CERT>"
   sp_key = "<SP_KEY>"
   uid_field = "<UID_FIELD>"
@@ -31,27 +32,26 @@ resource "rancher2_auth_config_ping" "ping" {
 
 The following arguments are supported:
 
-* `display_name_field` - (Required) Ping display name field (string).
-* `final_redirect_url` - (Required) Ping final redirect url (string).
-* `groups_field` - (Required) Ping group field (string).
-* `idp_metadata_content` - (Required) Ping IDP metadata content (string).
-* `rancher_api_host` - (Required) Rancher API host (string).
-* `sp_cert` - (Required/Sensitive) Ping SP cert (string).
-* `sp_key` - (Required/Sensitive) Ping SP key (string).
-* `uid_field` - (Required) Ping UID field (string).
-* `user_name_field` - (Required) Ping user name field (string).
-* `access_mode` - (Optional) Access mode for auth. `required`, `restricted`, `unrestricted` are supported. Default `unrestricted`
-* `allowed_principal_ids` - (Optional) Allowed principal ids for auth. Required if `access_mode` is `required` or `restricted`. Ex: `ping_user://<USER_ID>`  `ping_group://<GROUP_ID>`
-* `enabled` - (Optional) Enable auth config provider. Default `true`.
-* `annotations` - (Optional/Computed) Annotations of the resource (map).
-* `labels` - (Optional/Computed) Labels of the resource (map).
+* `display_name_field` - (Required) Ping display name field (string)
+* `groups_field` - (Required) Ping group field (string)
+* `idp_metadata_content` - (Required/Sensitive) Ping IDP metadata content (string)
+* `rancher_api_host` - (Required) Rancher url. Schema needs to be specified, `https://<RANCHER_API_HOST>` (string)
+* `sp_cert` - (Required/Sensitive) Ping SP cert (string)
+* `sp_key` - (Required/Sensitive) Ping SP key (string)
+* `uid_field` - (Required) Ping UID field (string)
+* `user_name_field` - (Required) Ping user name field (string)
+* `access_mode` - (Optional) Access mode for auth. `required`, `restricted`, `unrestricted` are supported. Default `unrestricted` (string)
+* `allowed_principal_ids` - (Optional) Allowed principal ids for auth. Required if `access_mode` is `required` or `restricted`. Ex: `ping_user://<USER_ID>`  `ping_group://<GROUP_ID>` (list)
+* `enabled` - (Optional) Enable auth config provider. Default `true` (bool)
+* `annotations` - (Optional/Computed) Annotations of the resource (map)
+* `labels` - (Optional/Computed) Labels of the resource (map)
                 
 
 ## Attributes Reference
 
 The following attributes are exported:
 
-* `id` - (Computed) The ID of the resource.
-* `name` - (Computed) The name of the resource.
-* `type` - (Computed) The type of the resource.
+* `id` - (Computed) The ID of the resource (string)
+* `name` - (Computed) The name of the resource (string)
+* `type` - (Computed) The type of the resource (string)
 


### PR DESCRIPTION
This PR contains:
- Updated auth config resources removing test on apply.
- Updated docs for auth config resources.
- Updated auth config resources checking that no other auth config but `local` is enabled.
- Go tests for auth config resources.
- Fix issues #59, #60, #66 and one point on #67