### PR TITLE
Update drone build image to golang:1.12.3 to fix go fmt issues

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,7 +4,7 @@ name: default
 
 steps:
 - name: build
-  image: golang:1.9.4
+  image: golang:1.12.3
   commands:
   - apt-get update
   - apt-get install -y xz-utils zip rsync jq curl ca-certificates
@@ -16,7 +16,7 @@ steps:
   - make package-rancher
 
 - name: build-all-binaries
-  image: golang:1.9.4
+  image: golang:1.12.3
   environment:
     CROSS: 1
   commands:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Requirements
 ------------
 
 - [Terraform](https://www.terraform.io/downloads.html) 0.11.x
-- [Go](https://golang.org/doc/install) 1.9 to build the provider plugin
+- [Go](https://golang.org/doc/install) 1.12 to build the provider plugin
 - [Trash](https://github.com/rancher/trash/releases) 0.2.6 to manage vendor dependencies
 - [Docker](https://docs.docker.com/install/) 17.03.x to run acceptance tests
 

--- a/rancher2/resource_rancher2_node_template.go
+++ b/rancher2/resource_rancher2_node_template.go
@@ -444,7 +444,7 @@ func resourceRancher2NodeTemplateUpdate(d *schema.ResourceData, meta interface{}
 	}
 
 	update := map[string]interface{}{
-		"name": d.Get("name").(string),
+		"name":                     d.Get("name").(string),
 		"authCertificateAuthority": d.Get("auth_certificate_authority").(string),
 		"authKey":                  d.Get("auth_key").(string),
 		"description":              d.Get("description").(string),


### PR DESCRIPTION
Updated drone build image to golang:1.12.3 to fix go fmt issues. 

`make fmt` on laptop is using local golang installation, probably 1.11 or 1.12 , but drone is using golang:1.9.4 docker image for build the provider. It seems that go fmt rules have changed from golang 1.9 to 1.11 or 1.12. 

e.g.: PR #70 #75  https://github.com/rancher/terraform-provider-rancher2/blob/master/rancher2/resource_rancher2_node_template.go#L447 line is well formatted on 1.9 but wrong on 1.11 or 1.12. 

Fix one point on #67