### PR TITLE
Add generic_config to node template resource

### DIFF
--- a/rancher2/resource_rancher2_cloud_credential_test.go
+++ b/rancher2/resource_rancher2_cloud_credential_test.go
@@ -109,6 +109,47 @@ resource "rancher2_cloud_credential" "foo" {
   }
 }
  `
+	testAccRancher2CloudCredentialConfigGeneric = `
+resource "rancher2_cloud_credential" "foo" {
+  name = "foo"
+  description= "Terraform cloudCredential acceptance test"
+  generic_credential_config {
+    driver = "rackspace"
+	config {
+      username = "XXXXXXXXXXXXXXXXXXXX"
+      apiKey   = "XXXXXXXXXXXXXXXXXXXX"
+    }
+  }
+}
+`
+
+	testAccRancher2CloudCredentialUpdateConfigGeneric = `
+resource "rancher2_cloud_credential" "foo" {
+  name = "foo"
+  description= "Terraform cloudCredential acceptance test - updated"
+  generic_credential_config {
+    driver = "rackspace"
+	config {
+      username = "YYYYYYYYYYYYYYYYYYYY"
+      apiKey   = "YYYYYYYYYYYYYYYYYYYY"
+    }
+  }
+}
+ `
+
+	testAccRancher2CloudCredentialRecreateConfigGeneric = `
+resource "rancher2_cloud_credential" "foo" {
+  name = "foo"
+  description= "Terraform cloudCredential acceptance test"
+  generic_credential_config {
+    driver = "rackspace"
+	config {
+      username = "XXXXXXXXXXXXXXXXXXXX"
+      apiKey   = "XXXXXXXXXXXXXXXXXXXX"
+    }
+  }
+}
+ `
 	testAccRancher2CloudCredentialConfigOpenstack = `
 resource "rancher2_cloud_credential" "foo" {
   name = "foo"
@@ -351,6 +392,71 @@ func TestAccRancher2CloudCredential_disappears_Digitalocean(t *testing.T) {
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccRancher2CloudCredentialConfigDigitalocean,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2CloudCredentialExists(testAccRancher2CloudCredentialType+".foo", cloudCredential),
+					testAccRancher2CloudCredentialDisappears(cloudCredential),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccRancher2CloudCredential_basic_Generic(t *testing.T) {
+	var cloudCredential *CloudCredential
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRancher2CloudCredentialDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRancher2CloudCredentialConfigGeneric,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2CloudCredentialExists(testAccRancher2CloudCredentialType+".foo", cloudCredential),
+					resource.TestCheckResourceAttr(testAccRancher2CloudCredentialType+".foo", "name", "foo"),
+					resource.TestCheckResourceAttr(testAccRancher2CloudCredentialType+".foo", "description", "Terraform cloudCredential acceptance test"),
+					resource.TestCheckResourceAttr(testAccRancher2CloudCredentialType+".foo", "driver", "rackspace"),
+					resource.TestCheckResourceAttr(testAccRancher2CloudCredentialType+".foo", "generic_credential_config.0.config.username", "XXXXXXXXXXXXXXXXXXXX"),
+					resource.TestCheckResourceAttr(testAccRancher2CloudCredentialType+".foo", "generic_credential_config.0.config.apiKey", "XXXXXXXXXXXXXXXXXXXX"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccRancher2CloudCredentialUpdateConfigGeneric,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2CloudCredentialExists(testAccRancher2CloudCredentialType+".foo", cloudCredential),
+					resource.TestCheckResourceAttr(testAccRancher2CloudCredentialType+".foo", "name", "foo"),
+					resource.TestCheckResourceAttr(testAccRancher2CloudCredentialType+".foo", "description", "Terraform cloudCredential acceptance test - updated"),
+					resource.TestCheckResourceAttr(testAccRancher2CloudCredentialType+".foo", "driver", "rackspace"),
+					resource.TestCheckResourceAttr(testAccRancher2CloudCredentialType+".foo", "generic_credential_config.0.config.username", "YYYYYYYYYYYYYYYYYYYY"),
+					resource.TestCheckResourceAttr(testAccRancher2CloudCredentialType+".foo", "generic_credential_config.0.config.apiKey", "YYYYYYYYYYYYYYYYYYYY"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccRancher2CloudCredentialRecreateConfigGeneric,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2CloudCredentialExists(testAccRancher2CloudCredentialType+".foo", cloudCredential),
+					resource.TestCheckResourceAttr(testAccRancher2CloudCredentialType+".foo", "name", "foo"),
+					resource.TestCheckResourceAttr(testAccRancher2CloudCredentialType+".foo", "description", "Terraform cloudCredential acceptance test"),
+					resource.TestCheckResourceAttr(testAccRancher2CloudCredentialType+".foo", "driver", "rackspace"),
+					resource.TestCheckResourceAttr(testAccRancher2CloudCredentialType+".foo", "generic_credential_config.0.config.username", "XXXXXXXXXXXXXXXXXXXX"),
+					resource.TestCheckResourceAttr(testAccRancher2CloudCredentialType+".foo", "generic_credential_config.0.config.apiKey", "XXXXXXXXXXXXXXXXXXXX"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRancher2CloudCredential_disappears_Generic(t *testing.T) {
+	var cloudCredential *CloudCredential
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRancher2CloudCredentialDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRancher2CloudCredentialConfigGeneric,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRancher2CloudCredentialExists(testAccRancher2CloudCredentialType+".foo", cloudCredential),
 					testAccRancher2CloudCredentialDisappears(cloudCredential),

--- a/rancher2/resource_rancher2_node_template_test.go
+++ b/rancher2/resource_rancher2_node_template_test.go
@@ -124,6 +124,49 @@ resource "rancher2_node_template" "foo" {
   }
 }
 `
+	testAccRancher2NodeTemplateConfigGeneric = testAccRancher2CloudCredentialConfigGeneric + `
+resource "rancher2_node_template" "foo" {
+  name = "foo"
+  description = "Terraform node driver generic acceptance test"
+  cloud_credential_id = "${rancher2_cloud_credential.foo.id}"
+  generic_config {
+    driver = "rackspace"
+    config {
+      flavorId    = "flavor-XXXXXXXX"
+      region      = "region-XXXXXXXX"
+    }
+  }
+}
+`
+
+	testAccRancher2NodeTemplateUpdateConfigGeneric = testAccRancher2CloudCredentialConfigGeneric + `
+resource "rancher2_node_template" "foo" {
+  name = "foo2"
+  description = "Terraform node driver generic acceptance test - updated"
+  cloud_credential_id = "${rancher2_cloud_credential.foo.id}"
+  generic_config {
+    driver = "rackspace"
+    config {
+      flavorId    = "flavor-YYYYYYYY"
+      region      = "region-YYYYYYYY"
+    }
+  }
+}
+`
+	testAccRancher2NodeTemplateRecreateConfigGeneric = testAccRancher2CloudCredentialConfigGeneric + `
+resource "rancher2_node_template" "foo" {
+  name = "foo"
+  description = "Terraform node driver generic acceptance test"
+  cloud_credential_id = "${rancher2_cloud_credential.foo.id}"
+  generic_config {
+    driver = "rackspace"
+    config {
+      flavorId    = "flavor-XXXXXXXX"
+      region      = "region-XXXXXXXX"
+    }
+  }
+}
+`
 	testAccRancher2NodeTemplateConfigOpenstack = testAccRancher2CloudCredentialConfigOpenstack + `
 resource "rancher2_node_template" "foo" {
   name = "foo"
@@ -395,6 +438,72 @@ func TestAccRancher2NodeTemplate_disappears_Digitalocean(t *testing.T) {
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccRancher2NodeTemplateConfigDigitalocean,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2NodeTemplateExists(testAccRancher2NodeTemplateType+".foo", nodeTemplate),
+					testAccRancher2NodeTemplateDisappears(nodeTemplate),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccRancher2NodeTemplate_basic_Generic(t *testing.T) {
+	var nodeTemplate *NodeTemplate
+
+	name := testAccRancher2NodeTemplateType + ".foo"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRancher2NodeTemplateDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRancher2NodeTemplateConfigGeneric,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2NodeTemplateExists(name, nodeTemplate),
+					resource.TestCheckResourceAttr(name, "name", "foo"),
+					resource.TestCheckResourceAttr(name, "description", "Terraform node driver generic acceptance test"),
+					resource.TestCheckResourceAttr(name, "driver", "rackspace"),
+					resource.TestCheckResourceAttr(name, "generic_config.0.config.flavorId", "flavor-XXXXXXXX"),
+					resource.TestCheckResourceAttr(name, "generic_config.0.config.region", "region-XXXXXXXX"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccRancher2NodeTemplateUpdateConfigGeneric,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2NodeTemplateExists(name, nodeTemplate),
+					resource.TestCheckResourceAttr(name, "name", "foo2"),
+					resource.TestCheckResourceAttr(name, "description", "Terraform node driver generic acceptance test - updated"),
+					resource.TestCheckResourceAttr(name, "driver", "rackspace"),
+					resource.TestCheckResourceAttr(name, "generic_config.0.config.flavorId", "flavor-YYYYYYYY"),
+					resource.TestCheckResourceAttr(name, "generic_config.0.config.region", "region-YYYYYYYY"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccRancher2NodeTemplateRecreateConfigGeneric,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2NodeTemplateExists(name, nodeTemplate),
+					resource.TestCheckResourceAttr(name, "name", "foo"),
+					resource.TestCheckResourceAttr(name, "description", "Terraform node driver generic acceptance test"),
+					resource.TestCheckResourceAttr(name, "driver", "rackspace"),
+					resource.TestCheckResourceAttr(name, "generic_config.0.config.flavorId", "flavor-XXXXXXXX"),
+					resource.TestCheckResourceAttr(name, "generic_config.0.config.region", "region-XXXXXXXX"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRancher2NodeTemplate_disappears_Generic(t *testing.T) {
+	var nodeTemplate *NodeTemplate
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRancher2NodeTemplateDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRancher2NodeTemplateConfigGeneric,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRancher2NodeTemplateExists(testAccRancher2NodeTemplateType+".foo", nodeTemplate),
 					testAccRancher2NodeTemplateDisappears(nodeTemplate),

--- a/rancher2/schema_cloud_credential.go
+++ b/rancher2/schema_cloud_credential.go
@@ -1,6 +1,9 @@
 package rancher2
 
 import (
+	"encoding/json"
+	"strings"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	managementClient "github.com/rancher/types/client/management/v3"
 )
@@ -14,6 +17,89 @@ type CloudCredential struct {
 	DigitaloceanCredentialConfig  *digitaloceanCredentialConfig  `json:"digitaloceancredentialConfig,omitempty" yaml:"digitaloceancredentialConfig,omitempty"`
 	OpenstackCredentialConfig     *openstackCredentialConfig     `json:"openstackcredentialConfig,omitempty" yaml:"openstackcredentialConfig,omitempty"`
 	VmwarevsphereCredentialConfig *vmwarevsphereCredentialConfig `json:"vmwarevspherecredentialConfig,omitempty" yaml:"vmwarevspherecredentialConfig,omitempty"`
+	genericCredentialConfig       *genericCredentialConfig
+}
+
+const credentialConfigKeySuffix = "credentialConfig"
+
+func isTypedCredentialConfigKey(key string) bool {
+	typedDrivers := []string{amazonec2ConfigDriver, azureConfigDriver, digitaloceanConfigDriver, openstackConfigDriver, vmwarevsphereConfigDriver}
+	for _, dn := range typedDrivers {
+		if key == dn+credentialConfigKeySuffix {
+			return true
+		}
+	}
+	return false
+}
+
+func (n *CloudCredential) driverName() string {
+	switch {
+	case n.Amazonec2CredentialConfig != nil:
+		return amazonec2ConfigDriver
+	case n.AzureCredentialConfig != nil:
+		return azureConfigDriver
+	case n.DigitaloceanCredentialConfig != nil:
+		return digitaloceanConfigDriver
+	case n.OpenstackCredentialConfig != nil:
+		return openstackConfigDriver
+	case n.VmwarevsphereCredentialConfig != nil:
+		return vmwarevsphereConfigDriver
+	case n.genericCredentialConfig != nil:
+		return n.genericCredentialConfig.driverName
+	}
+	return ""
+}
+
+func (n *CloudCredential) UnmarshalJSON(data []byte) error {
+	type Alias CloudCredential
+	var dest Alias
+	if err := json.Unmarshal(data, &dest); err != nil {
+		return err
+	}
+
+	var rawValues map[string]interface{}
+	if err := json.Unmarshal(data, &rawValues); err != nil {
+		return err
+	}
+
+	for key, value := range rawValues {
+		if strings.HasSuffix(key, credentialConfigKeySuffix) && !isTypedCredentialConfigKey(key) {
+			driverName := strings.Replace(key, credentialConfigKeySuffix, "", -1)
+			if cv, ok := value.(map[string]interface{}); ok {
+				dest.genericCredentialConfig = &genericCredentialConfig{
+					driverName: driverName,
+					config:     cv,
+				}
+			}
+		}
+	}
+
+	*n = CloudCredential(dest)
+	return nil
+}
+
+func (n *CloudCredential) MarshalJSON() ([]byte, error) {
+	type Alias CloudCredential
+	data, err := json.Marshal(&struct {
+		*Alias
+	}{
+		Alias: (*Alias)(n),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var results map[string]interface{}
+	if err := json.Unmarshal(data, &results); err != nil {
+		return nil, err
+	}
+
+	if n.genericCredentialConfig != nil {
+		configName := n.driverName() + credentialConfigKeySuffix
+		results[configName] = n.genericCredentialConfig.config
+	}
+
+	return json.Marshal(results)
 }
 
 //Schemas
@@ -28,7 +114,7 @@ func cloudCredentialFields() map[string]*schema.Schema {
 			Type:          schema.TypeList,
 			MaxItems:      1,
 			Optional:      true,
-			ConflictsWith: []string{"azure_credential_config", "digitalocean_credential_config", "openstack_credential_config", "vsphere_credential_config"},
+			ConflictsWith: []string{"azure_credential_config", "digitalocean_credential_config", "generic_credential_config", "openstack_credential_config", "vsphere_credential_config"},
 			Elem: &schema.Resource{
 				Schema: cloudCredentialAmazonec2Fields(),
 			},
@@ -37,7 +123,7 @@ func cloudCredentialFields() map[string]*schema.Schema {
 			Type:          schema.TypeList,
 			MaxItems:      1,
 			Optional:      true,
-			ConflictsWith: []string{"amazonec2_credential_config", "digitalocean_credential_config", "openstack_credential_config", "vsphere_credential_config"},
+			ConflictsWith: []string{"amazonec2_credential_config", "digitalocean_credential_config", "generic_credential_config", "openstack_credential_config", "vsphere_credential_config"},
 			Elem: &schema.Resource{
 				Schema: cloudCredentialAzureFields(),
 			},
@@ -50,7 +136,7 @@ func cloudCredentialFields() map[string]*schema.Schema {
 			Type:          schema.TypeList,
 			MaxItems:      1,
 			Optional:      true,
-			ConflictsWith: []string{"amazonec2_credential_config", "azure_credential_config", "openstack_credential_config", "vsphere_credential_config"},
+			ConflictsWith: []string{"amazonec2_credential_config", "azure_credential_config", "generic_credential_config", "openstack_credential_config", "vsphere_credential_config"},
 			Elem: &schema.Resource{
 				Schema: cloudCredentialDigitaloceanFields(),
 			},
@@ -59,11 +145,20 @@ func cloudCredentialFields() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Computed: true,
 		},
+		"generic_credential_config": &schema.Schema{
+			Type:          schema.TypeList,
+			MaxItems:      1,
+			Optional:      true,
+			ConflictsWith: []string{"amazonec2_credential_config", "azure_credential_config", "digitalocean_credential_config", "openstack_credential_config", "vsphere_credential_config"},
+			Elem: &schema.Resource{
+				Schema: cloudCredentialGenericFields(),
+			},
+		},
 		"openstack_credential_config": &schema.Schema{
 			Type:          schema.TypeList,
 			MaxItems:      1,
 			Optional:      true,
-			ConflictsWith: []string{"amazonec2_credential_config", "azure_credential_config", "digitalocean_credential_config", "vsphere_credential_config"},
+			ConflictsWith: []string{"amazonec2_credential_config", "azure_credential_config", "digitalocean_credential_config", "generic_credential_config", "vsphere_credential_config"},
 			Elem: &schema.Resource{
 				Schema: cloudCredentialOpenstackFields(),
 			},
@@ -72,7 +167,7 @@ func cloudCredentialFields() map[string]*schema.Schema {
 			Type:          schema.TypeList,
 			MaxItems:      1,
 			Optional:      true,
-			ConflictsWith: []string{"amazonec2_credential_config", "azure_credential_config", "digitalocean_credential_config", "openstack_credential_config"},
+			ConflictsWith: []string{"amazonec2_credential_config", "azure_credential_config", "digitalocean_credential_config", "generic_credential_config", "openstack_credential_config"},
 			Elem: &schema.Resource{
 				Schema: cloudCredentialVsphereFields(),
 			},

--- a/rancher2/schema_cloud_credential_generic.go
+++ b/rancher2/schema_cloud_credential_generic.go
@@ -1,0 +1,32 @@
+package rancher2
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+//Types
+
+type genericCredentialConfig struct {
+	driverName string
+	driverID   string
+	config     map[string]interface{}
+}
+
+//Schemas
+
+func cloudCredentialGenericFields() map[string]*schema.Schema {
+	s := map[string]*schema.Schema{
+		"driver": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "NodeDriver Name for generic node driver",
+		},
+		"config": {
+			Type:        schema.TypeMap,
+			Required:    true,
+			Description: "Cloud credential config for generic node driver",
+		},
+	}
+
+	return s
+}

--- a/rancher2/schema_cloud_credential_test.go
+++ b/rancher2/schema_cloud_credential_test.go
@@ -1,0 +1,134 @@
+package rancher2
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	managementClient "github.com/rancher/types/client/management/v3"
+)
+
+func TestCloudCredentialMarshalJSON(t *testing.T) {
+	cases := []struct {
+		Input          *CloudCredential
+		ExpectedOutput map[string]interface{}
+	}{
+		{
+			Input: &CloudCredential{
+				CloudCredential: managementClient.CloudCredential{
+					Name: "azure",
+				},
+				AzureCredentialConfig: &azureCredentialConfig{
+					ClientID:       "XXXXXXXXXXXXXXXXXXXX",
+					ClientSecret:   "XXXXXXXXXXXXXXXXXXXX",
+					SubscriptionID: "XXXXXXXXXXXXXXXXXXXX",
+				},
+			},
+			ExpectedOutput: map[string]interface{}{
+				"name":    "azure",
+				"actions": nil,
+				"links":   nil,
+				"azurecredentialConfig": map[string]interface{}{
+					"clientId":       "XXXXXXXXXXXXXXXXXXXX",
+					"clientSecret":   "XXXXXXXXXXXXXXXXXXXX",
+					"subscriptionId": "XXXXXXXXXXXXXXXXXXXX",
+				},
+			},
+		},
+		{
+			Input: &CloudCredential{
+				CloudCredential: managementClient.CloudCredential{
+					Name: "test",
+				},
+				genericCredentialConfig: &genericCredentialConfig{
+					driverName: "test",
+					config: map[string]interface{}{
+						"foo": "1",
+						"bar": 2,
+					},
+				},
+			},
+			ExpectedOutput: map[string]interface{}{
+				"name":    "test",
+				"actions": nil,
+				"links":   nil,
+				"testcredentialConfig": map[string]interface{}{
+					"foo": "1",
+					"bar": float64(2),
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		data, err := json.Marshal(tc.Input)
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+
+		var marshaled map[string]interface{}
+		err = json.Unmarshal(data, &marshaled)
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+		if !reflect.DeepEqual(marshaled, tc.ExpectedOutput) {
+			t.Fatalf("Unexpected output from marshaler.\nExpected: %#v\nGiven:    %#v",
+				tc.ExpectedOutput, marshaled)
+		}
+	}
+}
+
+func TestCloudCredentialUnmarshalJSON(t *testing.T) {
+	cases := []struct {
+		Input          string
+		ExpectedOutput CloudCredential
+	}{
+		{
+			Input: `{"name":"test","testcredentialConfig":{"bar":2,"foo":"1"}}`,
+			ExpectedOutput: CloudCredential{
+				CloudCredential: managementClient.CloudCredential{
+					Name: "test",
+				},
+				genericCredentialConfig: &genericCredentialConfig{
+					driverName: "test",
+					config: map[string]interface{}{
+						"foo": "1",
+						"bar": 2,
+					},
+				},
+			},
+		},
+		{
+			Input: `{
+				"name":"azure",
+				"azurecredentialConfig": {
+					"clientId":"XXXXXXXXXXXXXXXXXXXX",
+					"clientSecret":"XXXXXXXXXXXXXXXXXXXX",
+					"subscriptionId":"XXXXXXXXXXXXXXXXXXXX"
+				}
+			}`,
+			ExpectedOutput: CloudCredential{
+				CloudCredential: managementClient.CloudCredential{
+					Name: "azure",
+				},
+				AzureCredentialConfig: &azureCredentialConfig{
+					ClientID:       "XXXXXXXXXXXXXXXXXXXX",
+					ClientSecret:   "XXXXXXXXXXXXXXXXXXXX",
+					SubscriptionID: "XXXXXXXXXXXXXXXXXXXX",
+				},
+			},
+		},
+	}
+
+	for _, expect := range cases {
+		var cc CloudCredential
+		err := json.Unmarshal([]byte(expect.Input), &cc)
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+		if !reflect.DeepEqual(cc.CloudCredential, expect.ExpectedOutput.CloudCredential) {
+			t.Fatalf("Unexpected output from unmarshaler .\nExpected: %#v\nGiven:    %#v",
+				expect.ExpectedOutput, cc)
+		}
+	}
+}

--- a/rancher2/schema_node_template_generic.go
+++ b/rancher2/schema_node_template_generic.go
@@ -1,0 +1,30 @@
+package rancher2
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+type genericNodeTemplateConfig struct {
+	driverName string
+	driverID   string
+	config     map[string]interface{}
+}
+
+//Schemas
+
+func genericNodeConfigFields() map[string]*schema.Schema {
+	s := map[string]*schema.Schema{
+		"driver": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "Custom NodeDriver Name",
+		},
+		"config": {
+			Type:        schema.TypeMap,
+			Required:    true,
+			Description: "Driver config for custom node driver",
+		},
+	}
+
+	return s
+}

--- a/rancher2/schema_node_template_test.go
+++ b/rancher2/schema_node_template_test.go
@@ -1,0 +1,136 @@
+package rancher2
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	managementClient "github.com/rancher/types/client/management/v3"
+)
+
+func TestNodeTemplateMarshalJSON(t *testing.T) {
+	cases := []struct {
+		Input          *NodeTemplate
+		ExpectedOutput map[string]interface{}
+	}{
+		{
+			Input: &NodeTemplate{
+				NodeTemplate: managementClient.NodeTemplate{
+					Driver: "test",
+				},
+				genericConfig: &genericNodeTemplateConfig{
+					driverID:   "test",
+					driverName: "test",
+					config: map[string]interface{}{
+						"foo": "1",
+						"bar": 2,
+					},
+				},
+			},
+			ExpectedOutput: map[string]interface{}{
+				"actions": nil,
+				"links":   nil,
+				"driver":  "test",
+				"testConfig": map[string]interface{}{
+					"foo": "1",
+					"bar": float64(2),
+				},
+			},
+		},
+		{
+			Input: &NodeTemplate{
+				NodeTemplate: managementClient.NodeTemplate{
+					Driver: "azure",
+				},
+				AzureConfig: &azureConfig{
+					ClientID:       "XXXXXXXXXXXXXXXXXXXX",
+					ClientSecret:   "XXXXXXXXXXXXXXXXXXXX",
+					SubscriptionID: "XXXXXXXXXXXXXXXXXXXX",
+				},
+			},
+			ExpectedOutput: map[string]interface{}{
+				"actions": nil,
+				"links":   nil,
+				"driver":  "azure",
+				"azureConfig": map[string]interface{}{
+					"clientId":       "XXXXXXXXXXXXXXXXXXXX",
+					"clientSecret":   "XXXXXXXXXXXXXXXXXXXX",
+					"subscriptionId": "XXXXXXXXXXXXXXXXXXXX",
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		data, err := json.Marshal(tc.Input)
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+
+		var marshaled map[string]interface{}
+		err = json.Unmarshal(data, &marshaled)
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+		if !reflect.DeepEqual(marshaled, tc.ExpectedOutput) {
+			t.Fatalf("Unexpected output from marshaler.\nExpected: %#v\nGiven:    %#v",
+				tc.ExpectedOutput, marshaled)
+		}
+	}
+}
+
+func TestNodeTemplateUnmarshalJSON(t *testing.T) {
+	cases := []struct {
+		Input          string
+		ExpectedOutput NodeTemplate
+	}{
+		{
+			Input: `{"driver":"test","testConfig":{"bar":2,"foo":"test"}}`,
+			ExpectedOutput: NodeTemplate{
+				NodeTemplate: managementClient.NodeTemplate{
+					Driver: "test",
+				},
+				genericConfig: &genericNodeTemplateConfig{
+					driverName: "test",
+					config: map[string]interface{}{
+						"foo": "test",
+						"bar": float64(2),
+					},
+				},
+			},
+		},
+		{
+			Input: `{
+				"driver": "azure",
+				"azureConfig": {
+					"clientId": "XXXXXXXXXXXXXXXXXXXX",
+			    	"clientSecret": "XXXXXXXXXXXXXXXXXXXX",
+    				"subscriptionId": "XXXXXXXXXXXXXXXXXXXX"
+				}
+			}`,
+			ExpectedOutput: NodeTemplate{
+				NodeTemplate: managementClient.NodeTemplate{
+					Driver: "azure",
+				},
+				AzureConfig: &azureConfig{
+					ClientID:       "XXXXXXXXXXXXXXXXXXXX",
+					ClientSecret:   "XXXXXXXXXXXXXXXXXXXX",
+					SubscriptionID: "XXXXXXXXXXXXXXXXXXXX",
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		var nt NodeTemplate
+		err := json.Unmarshal([]byte(tc.Input), &nt)
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+
+		if !reflect.DeepEqual(nt, tc.ExpectedOutput) {
+			t.Fatalf("Unexpected output from unmarshaler .\nExpected: %#v\nGiven:    %#v",
+				tc.ExpectedOutput, nt)
+		}
+	}
+}

--- a/rancher2/structure_cloud_credential.go
+++ b/rancher2/structure_cloud_credential.go
@@ -61,7 +61,11 @@ func flattenCloudCredential(d *schema.ResourceData, in *CloudCredential) error {
 		}
 		d.Set("vsphere_credential_config", flattenCloudCredentialVsphere(in.VmwarevsphereCredentialConfig, v))
 	default:
-		return fmt.Errorf("[ERROR] Unsupported driver on cloud credential: %s", driver)
+		v, ok := d.Get("generic_credential_config").([]interface{})
+		if !ok {
+			v = []interface{}{}
+		}
+		d.Set("generic_credential_config", flattenCloudCredentialGeneric(in.genericCredentialConfig, v))
 	}
 
 	if len(in.Annotations) > 0 {
@@ -83,10 +87,10 @@ func flattenCloudCredential(d *schema.ResourceData, in *CloudCredential) error {
 
 // Expanders
 
-func expandCloudCredential(in *schema.ResourceData) *CloudCredential {
+func expandCloudCredential(in *schema.ResourceData, finder nodeDriverFinder) (*CloudCredential, error) {
 	obj := &CloudCredential{}
 	if in == nil {
-		return nil
+		return nil, nil
 	}
 
 	if v := in.Id(); len(v) > 0 {
@@ -113,6 +117,19 @@ func expandCloudCredential(in *schema.ResourceData) *CloudCredential {
 		in.Set("driver", digitaloceanConfigDriver)
 	}
 
+	if v, ok := in.Get("generic_credential_config").([]interface{}); ok && len(v) > 0 {
+		gc, err := expandCloudCredentialGeneric(v, finder)
+		if err != nil {
+			return nil, err
+		}
+		switch gc.driverID {
+		case amazonec2ConfigDriver, azureConfigDriver, digitaloceanConfigDriver, openstackConfigDriver, vmwarevsphereConfigDriver:
+			return nil, fmt.Errorf("[ERROR] Driver %s can not be used with generic_credential_config", gc.driverID)
+		}
+		obj.genericCredentialConfig = gc
+		in.Set("driver", obj.genericCredentialConfig.driverName)
+	}
+
 	if v, ok := in.Get("openstack_credential_config").([]interface{}); ok && len(v) > 0 {
 		obj.OpenstackCredentialConfig = expandCloudCredentialOpenstack(v)
 		in.Set("driver", openstackConfigDriver)
@@ -131,5 +148,5 @@ func expandCloudCredential(in *schema.ResourceData) *CloudCredential {
 		obj.Labels = toMapString(v)
 	}
 
-	return obj
+	return obj, nil
 }

--- a/rancher2/structure_cloud_credential_generic.go
+++ b/rancher2/structure_cloud_credential_generic.go
@@ -1,0 +1,50 @@
+package rancher2
+
+// Flatteners
+
+func flattenCloudCredentialGeneric(in *genericCredentialConfig, p []interface{}) []interface{} {
+	var obj map[string]interface{}
+	if len(p) == 0 || p[0] == nil {
+		obj = make(map[string]interface{})
+	} else {
+		obj = p[0].(map[string]interface{})
+	}
+
+	if in == nil {
+		return []interface{}{}
+	}
+
+	if len(in.driverID) > 0 {
+		obj["driver"] = in.driverID
+	}
+	if len(in.config) > 0 {
+		obj["config"] = in.config
+	}
+
+	return []interface{}{obj}
+}
+
+// Expanders
+
+func expandCloudCredentialGeneric(p []interface{}, client nodeDriverFinder) (*genericCredentialConfig, error) {
+	obj := &genericCredentialConfig{}
+	if len(p) == 0 || p[0] == nil {
+		return obj, nil
+	}
+	in := p[0].(map[string]interface{})
+
+	if v, ok := in["driver"].(string); ok && len(v) > 0 {
+		obj.driverID = v
+		nodeDriver, err := client.ByID(obj.driverID)
+		if err != nil {
+			return nil, err
+		}
+		obj.driverName = nodeDriver.Name
+	}
+
+	if v, ok := in["config"].(map[string]interface{}); ok {
+		obj.config = v
+	}
+
+	return obj, nil
+}

--- a/rancher2/structure_cloud_credential_generic_test.go
+++ b/rancher2/structure_cloud_credential_generic_test.go
@@ -1,0 +1,95 @@
+package rancher2
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/rancher/norman/types"
+
+	managementClient "github.com/rancher/types/client/management/v3"
+)
+
+var (
+	testCloudCredentialGenericConf      *genericCredentialConfig
+	testCloudCredentialGenericInterface []interface{}
+)
+
+func init() {
+	testCloudCredentialGenericConf = &genericCredentialConfig{
+		driverID:   "rackspaceDriverID",
+		driverName: "rackspace",
+		config: map[string]interface{}{
+			"apiKey": "apiKey",
+		},
+	}
+	testCloudCredentialGenericInterface = []interface{}{
+		map[string]interface{}{
+			"driver": "rackspace",
+			"config": map[string]interface{}{
+				"apiKey": "apiKey",
+			},
+		},
+	}
+}
+
+func TestFlattenCloudCredentialGeneric(t *testing.T) {
+
+	cases := []struct {
+		Input          *genericCredentialConfig
+		ExpectedOutput []interface{}
+	}{
+		{
+			testCloudCredentialGenericConf,
+			testCloudCredentialGenericInterface,
+		},
+	}
+
+	for _, tc := range cases {
+		output := flattenCloudCredentialGeneric(tc.Input, tc.ExpectedOutput)
+		if !reflect.DeepEqual(output, tc.ExpectedOutput) {
+			t.Fatalf("Unexpected output from flattener.\nExpected: %#v\nGiven:    %#v",
+				tc.ExpectedOutput, output)
+		}
+	}
+}
+
+func TestExpandCloudCredentialGeneric(t *testing.T) {
+
+	cases := []struct {
+		Input          []interface{}
+		ExpectedOutput *genericCredentialConfig
+	}{
+		{
+			testCloudCredentialGenericInterface,
+			testCloudCredentialGenericConf,
+		},
+	}
+
+	for _, tc := range cases {
+		output, err := expandCloudCredentialGeneric(tc.Input, &dummyNodeDriverFinder{
+			driverID:   tc.ExpectedOutput.driverID,
+			driverName: tc.ExpectedOutput.driverName,
+		})
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+		if !reflect.DeepEqual(output, tc.ExpectedOutput) {
+			t.Fatalf("Unexpected output from expander.\nExpected: %#v\nGiven:    %#v",
+				tc.ExpectedOutput, output)
+		}
+	}
+}
+
+type dummyNodeDriverFinder struct {
+	driverID   string
+	driverName string
+}
+
+func (f *dummyNodeDriverFinder) ByID(id string) (*managementClient.NodeDriver, error) {
+	return &managementClient.NodeDriver{
+		Resource: types.Resource{
+			ID: f.driverID,
+		},
+		Name: f.driverName,
+	}, nil
+}

--- a/rancher2/structure_node_template.go
+++ b/rancher2/structure_node_template.go
@@ -47,7 +47,9 @@ func flattenNodeTemplate(d *schema.ResourceData, in *NodeTemplate) error {
 			return fmt.Errorf("[ERROR] Node template driver %s requires vsphere_config", in.Driver)
 		}
 	default:
-		return fmt.Errorf("[ERROR] Unsupported driver on node template: %s", in.Driver)
+		if in.genericConfig == nil {
+			return fmt.Errorf("[ERROR] Node template driver %s requires generic_config", in.Driver)
+		}
 	}
 
 	if len(in.AuthCertificateAuthority) > 0 {
@@ -158,10 +160,10 @@ func flattenNodeTemplate(d *schema.ResourceData, in *NodeTemplate) error {
 
 // Expanders
 
-func expandNodeTemplate(in *schema.ResourceData) *NodeTemplate {
+func expandNodeTemplate(in *schema.ResourceData, finder nodeDriverFinder) (*NodeTemplate, error) {
 	obj := &NodeTemplate{}
 	if in == nil {
-		return nil
+		return nil, nil
 	}
 
 	if v := in.Id(); len(v) > 0 {
@@ -228,6 +230,19 @@ func expandNodeTemplate(in *schema.ResourceData) *NodeTemplate {
 		obj.EngineStorageDriver = v
 	}
 
+	if v, ok := in.Get("generic_config").([]interface{}); ok && len(v) > 0 {
+		gc, err := expandGenericNodeTemplateConfig(v, finder)
+		if err != nil {
+			return nil, err
+		}
+		switch gc.driverID {
+		case amazonec2ConfigDriver, azureConfigDriver, digitaloceanConfigDriver, openstackConfigDriver, vmwarevsphereConfigDriver:
+			return nil, fmt.Errorf("[ERROR] Node template driver %s can not be used with generic_config", gc.driverID)
+		}
+		obj.genericConfig = gc
+		obj.Driver = obj.genericConfig.driverName
+	}
+
 	if v, ok := in.Get("openstack_config").([]interface{}); ok && len(v) > 0 {
 		obj.OpenstackConfig = expandOpenstackConfig(v)
 		obj.Driver = openstackConfigDriver
@@ -250,5 +265,5 @@ func expandNodeTemplate(in *schema.ResourceData) *NodeTemplate {
 		obj.Labels = toMapString(v)
 	}
 
-	return obj
+	return obj, nil
 }

--- a/rancher2/structure_node_template_generic.go
+++ b/rancher2/structure_node_template_generic.go
@@ -1,0 +1,32 @@
+package rancher2
+
+import managementClient "github.com/rancher/types/client/management/v3"
+
+// Expanders
+
+type nodeDriverFinder interface {
+	ByID(id string) (*managementClient.NodeDriver, error)
+}
+
+func expandGenericNodeTemplateConfig(p []interface{}, client nodeDriverFinder) (*genericNodeTemplateConfig, error) {
+	obj := &genericNodeTemplateConfig{}
+	if len(p) == 0 || p[0] == nil {
+		return obj, nil
+	}
+	in := p[0].(map[string]interface{})
+
+	if v, ok := in["driver"].(string); ok && len(v) > 0 {
+		obj.driverID = v
+		nodeDriver, err := client.ByID(obj.driverID)
+		if err != nil {
+			return nil, err
+		}
+		obj.driverName = nodeDriver.Name
+	}
+
+	if v, ok := in["config"].(map[string]interface{}); ok {
+		obj.config = v
+	}
+
+	return obj, nil
+}

--- a/website/docs/r/cloudCredential.html.markdown
+++ b/website/docs/r/cloudCredential.html.markdown
@@ -10,7 +10,15 @@ description: |-
 
 Provides a Rancher v2 Cloud Credential resource. This can be used to create Cloud Credential for rancher v2.2.x and retrieve their information. 
 
-amazonec2, azure, digitalocean, openstack and vsphere credentials config are supported for Cloud Credential.
+The following credentials config support typed parameters.
+
+- amazonec2
+- azure
+- digitalocean
+- openstack
+- vsphere
+
+Other credentials config can specify parameter as key/value pair using `generic_credential_config`.
 
 ## Example Usage
 
@@ -84,6 +92,58 @@ The following attributes are exported:
 * `username` - (Required) vSphere username (string)
 * `vcenter` - (Required) vSphere IP/hostname for vCenter (string)
 * `vcenter_port` - (Optional) vSphere Port for vCenter. Default `443` (string)
+
+### `generic_credential_config`
+
+#### Arguments
+
+* `driver` - (Required) The ID of the node driver 
+* `config` - (Required) The parameters used by node driver (map)
+
+#### Example Usage of `generic_credential_config`
+
+```hcl
+# with builtin driver
+resource "rancher2_cloud_credential" "example" {
+  name        = "example"
+  description = "cloud credential with builtin driver"
+
+  generic_config {
+    driver = "rackspace"
+    config {
+      username = "XXXXXXXXXXXXXXXXXXXX"
+      apiKey   = "XXXXXXXXXXXXXXXXXXXX"
+    }
+  }  
+}
+```
+
+```hcl
+# with custom driver
+resource "rancher2_node_driver" "example" {
+  active            = true
+  builtin           = false
+  checksum          = "xxx"
+  name              = "example"
+  ui_url            = "https://www.example.com/ui-driver-example/component.js"
+  url               = "https://www.example.com/ui-driver-example/docker-machine-driver-example_linux-amd64.zip"
+  whitelist_domains = ["www.example.com"]
+}
+
+resource "rancher2_cloud_credential" "example" {
+  name        = "example-credential"
+  description = "cloud credential with custom driver"
+
+  generic_config {
+    driver = "${rancher2_node_driver.example.id}"
+    config {
+      username = "XXXXXXXXXXXXXXXXXXXX"
+      apiKey   = "XXXXXXXXXXXXXXXXXXXX"
+    }
+  }  
+}
+
+```
 
 ## Timeouts
 


### PR DESCRIPTION
This PR adds `generic_config` to node template resource.
This allows driver specific parameters to be specified as key/value pairs to support various node drivers in the node template.

## Motivation

Rancher is supporting many node drivers.
However, this provider only supports `amazonec2`, `azure`, and `digitalocean` now.

It is extendable by implements driver specific codes(e.g.: for vsphere), but it limits Rancher's flexibility.

This PR opens the door to enable various node drivers to be used without driver specific codes.

## Implementation

- Added `generic_config` to schema of node template resource.
- The values specified by `generic_config` are held in NodeTemplate struct.
- NoteTemplate implements `MarshalJSON/UnmarshalJSON` to communicate driver specific parameters with the Rancher API.

## Example usage of `generic_config`

#### With builtin driver

```hcl
resource "rancher2_node_template" "foo" {
  name        = "foo"
  description = "Terraform node template with vsphere driver"

  generic_config {
    driver = "vmwarevsphere"

    config {
      # Specify driver specific parameters here
      username    = "XXXXXXXXXXXXXXXXXXXX"
      password    = "XXXXXXXXXXXXXXXXXXXX"
      vcenter     = "127.0.0.1"
      vcenterPort = "443"
    }
  }
}
```

#### With custom driver

```hcl
resource "rancher2_node_driver" "example" {
  active            = true
  builtin           = false
  checksum          = "xxx"
  name              = "example"
  ui_url            = "https://www.example.com/ui-driver-example/component.js"
  url               = "https://www.example.com/ui-driver-example/docker-machine-driver-example_linux-amd64.zip"
  whitelist_domains = ["www.example.com"]
}

resource "rancher2_node_template" "example" {
  name        = "example-template"
  description = "Terraform node template with generic driver"

  generic_config {
    driver = "${rancher2_node_driver.example.id}"

    config {
      # Specify driver specific parameters here
      username = "XXXXXXXXXXXXXXXXXXXX"
      password = "XXXXXXXXXXXXXXXXXXXX"
    }
  }
}
```