### PR TITLE
Moved resources import function to their own import file

### DIFF
--- a/rancher2/import_rancher2_catalog.go
+++ b/rancher2/import_rancher2_catalog.go
@@ -1,0 +1,23 @@
+package rancher2
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceRancher2CatalogImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	client, err := meta.(*Config).ManagementClient()
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+	catalog, err := client.Catalog.ByID(d.Id())
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+
+	err = flattenCatalog(d, catalog)
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/rancher2/import_rancher2_cluster.go
+++ b/rancher2/import_rancher2_cluster.go
@@ -1,0 +1,14 @@
+package rancher2
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceRancher2ClusterImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	err := resourceRancher2ClusterRead(d, meta)
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/rancher2/import_rancher2_cluster_logging.go
+++ b/rancher2/import_rancher2_cluster_logging.go
@@ -1,0 +1,23 @@
+package rancher2
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceRancher2ClusterLoggingImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	client, err := meta.(*Config).ManagementClient()
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+	clusterLogging, err := client.ClusterLogging.ByID(d.Id())
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+
+	err = flattenClusterLogging(d, clusterLogging)
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/rancher2/import_rancher2_cluster_role_template_binding.go
+++ b/rancher2/import_rancher2_cluster_role_template_binding.go
@@ -1,0 +1,23 @@
+package rancher2
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceRancher2ClusterRoleTemplateBindingImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	client, err := meta.(*Config).ManagementClient()
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+	clusterRole, err := client.ClusterRoleTemplateBinding.ByID(d.Id())
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+
+	err = flattenClusterRoleTemplateBinding(d, clusterRole)
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/rancher2/import_rancher2_namespace.go
+++ b/rancher2/import_rancher2_namespace.go
@@ -1,0 +1,29 @@
+package rancher2
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceRancher2NamespaceImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	clusterID, resourceID := splitID(d.Id())
+
+	client, err := meta.(*Config).ClusterClient(clusterID)
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+	err = d.Set("project_id", clusterID)
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+	ns, err := client.Namespace.ByID(resourceID)
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+
+	err = flattenNamespace(d, ns)
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/rancher2/import_rancher2_node_driver.go
+++ b/rancher2/import_rancher2_node_driver.go
@@ -1,0 +1,23 @@
+package rancher2
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceRancher2NodeDriverImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	client, err := meta.(*Config).ManagementClient()
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+	nodeDriver, err := client.NodeDriver.ByID(d.Id())
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+
+	err = flattenNodeDriver(d, nodeDriver)
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/rancher2/import_rancher2_node_pool.go
+++ b/rancher2/import_rancher2_node_pool.go
@@ -1,0 +1,23 @@
+package rancher2
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceRancher2NodePoolImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	client, err := meta.(*Config).ManagementClient()
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+	nodePool, err := client.NodePool.ByID(d.Id())
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+
+	err = flattenNodePool(d, nodePool)
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/rancher2/import_rancher2_node_template.go
+++ b/rancher2/import_rancher2_node_template.go
@@ -1,0 +1,25 @@
+package rancher2
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	managementClient "github.com/rancher/types/client/management/v3"
+)
+
+func resourceRancher2NodeTemplateImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	client, err := meta.(*Config).ManagementClient()
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+	nodeTemplate := &NodeTemplate{}
+	err = client.APIBaseClient.ByID(managementClient.NodeTemplateType, d.Id(), nodeTemplate)
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+
+	err = flattenNodeTemplate(d, nodeTemplate)
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/rancher2/import_rancher2_project.go
+++ b/rancher2/import_rancher2_project.go
@@ -1,0 +1,23 @@
+package rancher2
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceRancher2ProjectImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	client, err := meta.(*Config).ManagementClient()
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+	project, err := client.Project.ByID(d.Id())
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+
+	err = flattenProject(d, project)
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/rancher2/import_rancher2_project_logging.go
+++ b/rancher2/import_rancher2_project_logging.go
@@ -1,0 +1,23 @@
+package rancher2
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceRancher2ProjectLoggingImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	client, err := meta.(*Config).ManagementClient()
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+	projectLogging, err := client.ProjectLogging.ByID(d.Id())
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+
+	err = flattenProjectLogging(d, projectLogging)
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/rancher2/import_rancher2_project_role_template_binding.go
+++ b/rancher2/import_rancher2_project_role_template_binding.go
@@ -1,0 +1,23 @@
+package rancher2
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceRancher2ProjectRoleTemplateBindingImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	client, err := meta.(*Config).ManagementClient()
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+	projectRole, err := client.ProjectRoleTemplateBinding.ByID(d.Id())
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+
+	err = flattenProjectRoleTemplateBinding(d, projectRole)
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/rancher2/import_rancher2_setting.go
+++ b/rancher2/import_rancher2_setting.go
@@ -1,0 +1,23 @@
+package rancher2
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceRancher2SettingImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	client, err := meta.(*Config).ManagementClient()
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+	setting, err := client.Setting.ByID(d.Id())
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+
+	err = flattenSetting(d, setting)
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/rancher2/resource_rancher2_catalog.go
+++ b/rancher2/resource_rancher2_catalog.go
@@ -299,24 +299,6 @@ func resourceRancher2CatalogDelete(d *schema.ResourceData, meta interface{}) err
 	return nil
 }
 
-func resourceRancher2CatalogImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	client, err := meta.(*Config).ManagementClient()
-	if err != nil {
-		return []*schema.ResourceData{}, err
-	}
-	catalog, err := client.Catalog.ByID(d.Id())
-	if err != nil {
-		return []*schema.ResourceData{}, err
-	}
-
-	err = flattenCatalog(d, catalog)
-	if err != nil {
-		return []*schema.ResourceData{}, err
-	}
-
-	return []*schema.ResourceData{d}, nil
-}
-
 // catalogStateRefreshFunc returns a resource.StateRefreshFunc, used to watch a Rancher Catalog.
 func catalogStateRefreshFunc(client *managementClient.Client, catalogID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {

--- a/rancher2/resource_rancher2_cluster.go
+++ b/rancher2/resource_rancher2_cluster.go
@@ -485,15 +485,6 @@ func resourceRancher2ClusterDelete(d *schema.ResourceData, meta interface{}) err
 	return nil
 }
 
-func resourceRancher2ClusterImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	err := resourceRancher2ClusterRead(d, meta)
-	if err != nil {
-		return []*schema.ResourceData{}, err
-	}
-
-	return []*schema.ResourceData{d}, nil
-}
-
 // ClusterStateRefreshFunc returns a resource.StateRefreshFunc, used to watch a Rancher Cluster.
 func clusterStateRefreshFunc(client *managementClient.Client, clusterID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {

--- a/rancher2/resource_rancher2_cluster_logging.go
+++ b/rancher2/resource_rancher2_cluster_logging.go
@@ -510,24 +510,6 @@ func resourceRancher2ClusterLoggingDelete(d *schema.ResourceData, meta interface
 	return nil
 }
 
-func resourceRancher2ClusterLoggingImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	client, err := meta.(*Config).ManagementClient()
-	if err != nil {
-		return []*schema.ResourceData{}, err
-	}
-	clusterLogging, err := client.ClusterLogging.ByID(d.Id())
-	if err != nil {
-		return []*schema.ResourceData{}, err
-	}
-
-	err = flattenClusterLogging(d, clusterLogging)
-	if err != nil {
-		return []*schema.ResourceData{}, err
-	}
-
-	return []*schema.ResourceData{d}, nil
-}
-
 // clusterLoggingStateRefreshFunc returns a resource.StateRefreshFunc, used to watch a Rancher Cluster Role Template Binding.
 func clusterLoggingStateRefreshFunc(client *managementClient.Client, clusterLoggingID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {

--- a/rancher2/resource_rancher2_cluster_role_template_binding.go
+++ b/rancher2/resource_rancher2_cluster_role_template_binding.go
@@ -329,24 +329,6 @@ func resourceRancher2ClusterRoleTemplateBindingDelete(d *schema.ResourceData, me
 	return nil
 }
 
-func resourceRancher2ClusterRoleTemplateBindingImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	client, err := meta.(*Config).ManagementClient()
-	if err != nil {
-		return []*schema.ResourceData{}, err
-	}
-	clusterRole, err := client.ClusterRoleTemplateBinding.ByID(d.Id())
-	if err != nil {
-		return []*schema.ResourceData{}, err
-	}
-
-	err = flattenClusterRoleTemplateBinding(d, clusterRole)
-	if err != nil {
-		return []*schema.ResourceData{}, err
-	}
-
-	return []*schema.ResourceData{d}, nil
-}
-
 // clusterRoleTemplateBindingStateRefreshFunc returns a resource.StateRefreshFunc, used to watch a Rancher Cluster Role Template Binding.
 func clusterRoleTemplateBindingStateRefreshFunc(client *managementClient.Client, clusterRoleID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {

--- a/rancher2/resource_rancher2_namespace.go
+++ b/rancher2/resource_rancher2_namespace.go
@@ -383,30 +383,6 @@ func resourceRancher2NamespaceDelete(d *schema.ResourceData, meta interface{}) e
 	return nil
 }
 
-func resourceRancher2NamespaceImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	clusterID, resourceID := splitID(d.Id())
-
-	client, err := meta.(*Config).ClusterClient(clusterID)
-	if err != nil {
-		return []*schema.ResourceData{}, err
-	}
-	err = d.Set("project_id", clusterID)
-	if err != nil {
-		return []*schema.ResourceData{}, err
-	}
-	ns, err := client.Namespace.ByID(resourceID)
-	if err != nil {
-		return []*schema.ResourceData{}, err
-	}
-
-	err = flattenNamespace(d, ns)
-	if err != nil {
-		return []*schema.ResourceData{}, err
-	}
-
-	return []*schema.ResourceData{d}, nil
-}
-
 // namespaceStateRefreshFunc returns a resource.StateRefreshFunc, used to watch a Rancher Namespace.
 func namespaceStateRefreshFunc(client *clusterClient.Client, nsID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {

--- a/rancher2/resource_rancher2_node_driver.go
+++ b/rancher2/resource_rancher2_node_driver.go
@@ -335,24 +335,6 @@ func resourceRancher2NodeDriverDelete(d *schema.ResourceData, meta interface{}) 
 	return nil
 }
 
-func resourceRancher2NodeDriverImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	client, err := meta.(*Config).ManagementClient()
-	if err != nil {
-		return []*schema.ResourceData{}, err
-	}
-	nodeDriver, err := client.NodeDriver.ByID(d.Id())
-	if err != nil {
-		return []*schema.ResourceData{}, err
-	}
-
-	err = flattenNodeDriver(d, nodeDriver)
-	if err != nil {
-		return []*schema.ResourceData{}, err
-	}
-
-	return []*schema.ResourceData{d}, nil
-}
-
 // nodeDriverStateRefreshFunc returns a resource.StateRefreshFunc, used to watch a Rancher NodeDriver.
 func nodeDriverStateRefreshFunc(client *managementClient.Client, nodeDriverID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {

--- a/rancher2/resource_rancher2_node_pool.go
+++ b/rancher2/resource_rancher2_node_pool.go
@@ -326,24 +326,6 @@ func resourceRancher2NodePoolDelete(d *schema.ResourceData, meta interface{}) er
 	return nil
 }
 
-func resourceRancher2NodePoolImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	client, err := meta.(*Config).ManagementClient()
-	if err != nil {
-		return []*schema.ResourceData{}, err
-	}
-	nodePool, err := client.NodePool.ByID(d.Id())
-	if err != nil {
-		return []*schema.ResourceData{}, err
-	}
-
-	err = flattenNodePool(d, nodePool)
-	if err != nil {
-		return []*schema.ResourceData{}, err
-	}
-
-	return []*schema.ResourceData{d}, nil
-}
-
 // nodePoolStateRefreshFunc returns a resource.StateRefreshFunc, used to watch a Rancher NodePool.
 func nodePoolStateRefreshFunc(client *managementClient.Client, nodePoolID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {

--- a/rancher2/resource_rancher2_node_template.go
+++ b/rancher2/resource_rancher2_node_template.go
@@ -536,25 +536,6 @@ func resourceRancher2NodeTemplateDelete(d *schema.ResourceData, meta interface{}
 	return nil
 }
 
-func resourceRancher2NodeTemplateImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	client, err := meta.(*Config).ManagementClient()
-	if err != nil {
-		return []*schema.ResourceData{}, err
-	}
-	nodeTemplate := &NodeTemplate{}
-	err = client.APIBaseClient.ByID(managementClient.NodeTemplateType, d.Id(), nodeTemplate)
-	if err != nil {
-		return []*schema.ResourceData{}, err
-	}
-
-	err = flattenNodeTemplate(d, nodeTemplate)
-	if err != nil {
-		return []*schema.ResourceData{}, err
-	}
-
-	return []*schema.ResourceData{d}, nil
-}
-
 // nodeTemplateStateRefreshFunc returns a resource.StateRefreshFunc, used to watch a Rancher NodeTemplate.
 func nodeTemplateStateRefreshFunc(client *managementClient.Client, nodePoolID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {

--- a/rancher2/resource_rancher2_project.go
+++ b/rancher2/resource_rancher2_project.go
@@ -313,24 +313,6 @@ func resourceRancher2ProjectDelete(d *schema.ResourceData, meta interface{}) err
 	return nil
 }
 
-func resourceRancher2ProjectImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	client, err := meta.(*Config).ManagementClient()
-	if err != nil {
-		return []*schema.ResourceData{}, err
-	}
-	project, err := client.Project.ByID(d.Id())
-	if err != nil {
-		return []*schema.ResourceData{}, err
-	}
-
-	err = flattenProject(d, project)
-	if err != nil {
-		return []*schema.ResourceData{}, err
-	}
-
-	return []*schema.ResourceData{d}, nil
-}
-
 // projectStateRefreshFunc returns a resource.StateRefreshFunc, used to watch a Rancher Project.
 func projectStateRefreshFunc(client *managementClient.Client, projectID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {

--- a/rancher2/resource_rancher2_project_logging.go
+++ b/rancher2/resource_rancher2_project_logging.go
@@ -512,24 +512,6 @@ func resourceRancher2ProjectLoggingDelete(d *schema.ResourceData, meta interface
 	return nil
 }
 
-func resourceRancher2ProjectLoggingImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	client, err := meta.(*Config).ManagementClient()
-	if err != nil {
-		return []*schema.ResourceData{}, err
-	}
-	projectLogging, err := client.ProjectLogging.ByID(d.Id())
-	if err != nil {
-		return []*schema.ResourceData{}, err
-	}
-
-	err = flattenProjectLogging(d, projectLogging)
-	if err != nil {
-		return []*schema.ResourceData{}, err
-	}
-
-	return []*schema.ResourceData{d}, nil
-}
-
 // projectLoggingStateRefreshFunc returns a resource.StateRefreshFunc, used to watch a Rancher Cluster Role Template Binding.
 func projectLoggingStateRefreshFunc(client *managementClient.Client, projectLoggingID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {

--- a/rancher2/resource_rancher2_project_role_template_binding.go
+++ b/rancher2/resource_rancher2_project_role_template_binding.go
@@ -329,24 +329,6 @@ func resourceRancher2ProjectRoleTemplateBindingDelete(d *schema.ResourceData, me
 	return nil
 }
 
-func resourceRancher2ProjectRoleTemplateBindingImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	client, err := meta.(*Config).ManagementClient()
-	if err != nil {
-		return []*schema.ResourceData{}, err
-	}
-	projectRole, err := client.ProjectRoleTemplateBinding.ByID(d.Id())
-	if err != nil {
-		return []*schema.ResourceData{}, err
-	}
-
-	err = flattenProjectRoleTemplateBinding(d, projectRole)
-	if err != nil {
-		return []*schema.ResourceData{}, err
-	}
-
-	return []*schema.ResourceData{d}, nil
-}
-
 // PpojectRoleTemplateBindingStateRefreshFunc returns a resource.StateRefreshFunc, used to watch a Rancher Project Role Template Binding.
 func projectRoleTemplateBindingStateRefreshFunc(client *managementClient.Client, projectRoleID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {

--- a/rancher2/resource_rancher2_setting.go
+++ b/rancher2/resource_rancher2_setting.go
@@ -283,24 +283,6 @@ func resourceRancher2SettingDelete(d *schema.ResourceData, meta interface{}) err
 	return nil
 }
 
-func resourceRancher2SettingImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	client, err := meta.(*Config).ManagementClient()
-	if err != nil {
-		return []*schema.ResourceData{}, err
-	}
-	setting, err := client.Setting.ByID(d.Id())
-	if err != nil {
-		return []*schema.ResourceData{}, err
-	}
-
-	err = flattenSetting(d, setting)
-	if err != nil {
-		return []*schema.ResourceData{}, err
-	}
-
-	return []*schema.ResourceData{d}, nil
-}
-
 // settingStateRefreshFunc returns a resource.StateRefreshFunc, used to watch a Rancher Project.
 func settingStateRefreshFunc(client *managementClient.Client, settingID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {


### PR DESCRIPTION
Moved resources import function to their own `import_rancher2_<resource>.go`.

Fix 1 point on #67 